### PR TITLE
fix: fixed max number of PDF pages for Gemini 1.5

### DIFF
--- a/aidial_adapter_vertexai/chat/gemini/prompt/gemini_1_5.py
+++ b/aidial_adapter_vertexai/chat/gemini/prompt/gemini_1_5.py
@@ -36,7 +36,7 @@ class Gemini_1_5_Prompt(GeminiPrompt):
 
         processors = [
             get_image_processor(3000),
-            get_pdf_processor(3000),
+            get_pdf_processor(300),
             get_video_processor(10),
             get_audio_processor(),
         ]


### PR DESCRIPTION
As per [documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/document-understanding#supported_models)