### PR TITLE
fix: Fix variable overshadowing for multimodal embeddings

### DIFF
--- a/aidial_adapter_vertexai/embedding/multi_modal.py
+++ b/aidial_adapter_vertexai/embedding/multi_modal.py
@@ -225,5 +225,5 @@ class MultiModalEmbeddingsAdapter(EmbeddingsAdapter):
         return make_embeddings_response(
             model=self.model_id,
             embeddings=embeddings,
-            tokens=tokens,
+            tokens=total_tokens,
         )

--- a/aidial_adapter_vertexai/embedding/multi_modal.py
+++ b/aidial_adapter_vertexai/embedding/multi_modal.py
@@ -216,11 +216,11 @@ class MultiModalEmbeddingsAdapter(EmbeddingsAdapter):
             )
 
         embeddings: List[Embedding] = []
-        tokens = 0
+        total_tokens = 0
 
         for embedding, tokens in await gather_sync(tasks):
             embeddings.append(embedding)
-            tokens += tokens
+            total_tokens += tokens
 
         return make_embeddings_response(
             model=self.model_id,


### PR DESCRIPTION
`tokens += tokens` caused incorrect sum