### PR TITLE
fix: allow only one concurrent thread for `from_pretrained` due to vertex problem

### DIFF
--- a/aidial_adapter_vertexai/app.py
+++ b/aidial_adapter_vertexai/app.py
@@ -22,42 +22,9 @@ DEFAULT_REGION = get_env("DEFAULT_REGION")
 GCP_PROJECT_ID = get_env("GCP_PROJECT_ID")
 
 
-def _init_vertexai_client() -> None:
-    # TODO: For now assume that there will be only one project and location.
-    # We need to fix it otherwise.
-    vertexai.init(project=GCP_PROJECT_ID, location=DEFAULT_REGION)
-
-
-def _init_chat_completions(app: DIALApp) -> None:
-    for deployment in ChatCompletionDeployment:
-        app.add_chat_completion(
-            deployment.get_model_id(),
-            VertexAIChatCompletion(
-                project_id=GCP_PROJECT_ID,
-                region=DEFAULT_REGION,
-            ),
-        )
-
-
-def _init_embeddings(app: DIALApp) -> None:
-    for deployment in EmbeddingsDeployment:
-        app.add_embeddings(
-            deployment.get_model_id(),
-            VertexAIEmbeddings(
-                project_id=GCP_PROJECT_ID,
-                region=DEFAULT_REGION,
-            ),
-        )
-
-
 @asynccontextmanager
 async def lifespan(app: DIALApp):
-    # NOTE: configuring logger after the DIAL telemetry is initialized,
-    # because it may have configured the root logger on its own.
-    configure_loggers()
-    _init_vertexai_client()
-    _init_embeddings(app)
-    _init_chat_completions(app)
+    vertexai.init(project=GCP_PROJECT_ID, location=DEFAULT_REGION)
     yield
 
 
@@ -67,6 +34,10 @@ app = DIALApp(
     add_healthcheck=True,
     lifespan=lifespan,
 )
+
+# NOTE: configuring logger after the DIAL telemetry is initialized,
+# because it may have configured the root logger on its own.
+configure_loggers()
 
 
 @app.get("/openai/models")
@@ -78,3 +49,23 @@ async def models():
     ]
 
     return ModelsResponse(data=models)
+
+
+for deployment in ChatCompletionDeployment:
+    app.add_chat_completion(
+        deployment.get_model_id(),
+        VertexAIChatCompletion(
+            project_id=GCP_PROJECT_ID,
+            region=DEFAULT_REGION,
+        ),
+    )
+
+
+for deployment in EmbeddingsDeployment:
+    app.add_embeddings(
+        deployment.get_model_id(),
+        VertexAIEmbeddings(
+            project_id=GCP_PROJECT_ID,
+            region=DEFAULT_REGION,
+        ),
+    )

--- a/aidial_adapter_vertexai/app.py
+++ b/aidial_adapter_vertexai/app.py
@@ -23,6 +23,8 @@ GCP_PROJECT_ID = get_env("GCP_PROJECT_ID")
 
 
 def _init_vertexai_client() -> None:
+    # TODO: For now assume that there will be only one project and location.
+    # We need to fix it otherwise.
     vertexai.init(project=GCP_PROJECT_ID, location=DEFAULT_REGION)
 
 

--- a/aidial_adapter_vertexai/app.py
+++ b/aidial_adapter_vertexai/app.py
@@ -1,3 +1,4 @@
+import time
 from contextlib import asynccontextmanager
 
 import vertexai
@@ -15,8 +16,10 @@ from aidial_adapter_vertexai.dial_api.response import (
     ModelsResponse,
 )
 from aidial_adapter_vertexai.embeddings import VertexAIEmbeddings
+from aidial_adapter_vertexai.utils.concurrency import gather_sync
 from aidial_adapter_vertexai.utils.env import get_env
 from aidial_adapter_vertexai.utils.log_config import configure_loggers
+from aidial_adapter_vertexai.vertex_ai import DEPLOYMENT_TO_CONSTRUCTOR
 
 DEFAULT_REGION = get_env("DEFAULT_REGION")
 GCP_PROJECT_ID = get_env("GCP_PROJECT_ID")
@@ -50,7 +53,22 @@ def _init_embeddings(app: DIALApp) -> None:
 
 @asynccontextmanager
 async def lifespan(app: DIALApp):
+    vertex_start_time = time.time()
     _init_vertexai_client()
+
+    print(
+        f"VertexAI client initialized in {time.time() - vertex_start_time} seconds"
+    )
+
+    start_time = time.time()
+
+    tasks = [
+        lambda: DEPLOYMENT_TO_CONSTRUCTOR[deployment](deployment.get_model_id())
+        for deployment in ChatCompletionDeployment
+    ]
+    await gather_sync(tasks)
+    print(f"Model initialized in {time.time() - start_time} seconds")
+
     _init_embeddings(app)
     _init_chat_completions(app)
     yield

--- a/aidial_adapter_vertexai/chat/bison/adapter.py
+++ b/aidial_adapter_vertexai/chat/bison/adapter.py
@@ -10,7 +10,6 @@ from aidial_adapter_vertexai.dial_api.request import ModelParameters
 from aidial_adapter_vertexai.vertex_ai import (
     get_chat_model,
     get_code_chat_model,
-    init_vertex_ai,
 )
 
 
@@ -52,7 +51,6 @@ class BisonChatAdapter(BisonChatCompletionAdapter):
     async def create(
         cls, model_id: str, project_id: str, location: str
     ) -> "BisonChatAdapter":
-        await init_vertex_ai(project_id, location)
         return cls(await get_chat_model(model_id))
 
     def prepare_parameters_no_stream(
@@ -108,7 +106,6 @@ class BisonCodeChatAdapter(BisonChatCompletionAdapter):
     async def create(
         cls, model_id: str, project_id: str, location: str
     ) -> "BisonCodeChatAdapter":
-        await init_vertex_ai(project_id, location)
         return cls(await get_code_chat_model(model_id))
 
     def validate_parameters(self, params: ModelParameters) -> None:

--- a/aidial_adapter_vertexai/chat/gemini/adapter.py
+++ b/aidial_adapter_vertexai/chat/gemini/adapter.py
@@ -46,7 +46,7 @@ from aidial_adapter_vertexai.utils.json import json_dumps, json_dumps_short
 from aidial_adapter_vertexai.utils.log_config import vertex_ai_logger as log
 from aidial_adapter_vertexai.utils.protobuf import recurse_proto_marshal_to_dict
 from aidial_adapter_vertexai.utils.timer import Timer
-from aidial_adapter_vertexai.vertex_ai import get_gemini_model, init_vertex_ai
+from aidial_adapter_vertexai.vertex_ai import get_gemini_model
 
 HarmCategory = generative_models.HarmCategory
 HarmBlockThreshold = generative_models.HarmBlockThreshold
@@ -220,7 +220,6 @@ class GeminiChatCompletionAdapter(ChatCompletionAdapter[GeminiPrompt]):
         project_id: str,
         location: str,
     ) -> "GeminiChatCompletionAdapter":
-        await init_vertex_ai(project_id, location)
         model = await get_gemini_model(model_id)
         return cls(file_storage, model, deployment)
 

--- a/aidial_adapter_vertexai/chat/imagen/adapter.py
+++ b/aidial_adapter_vertexai/chat/imagen/adapter.py
@@ -23,10 +23,7 @@ from aidial_adapter_vertexai.dial_api.storage import (
 from aidial_adapter_vertexai.dial_api.token_usage import TokenUsage
 from aidial_adapter_vertexai.utils.log_config import vertex_ai_logger as log
 from aidial_adapter_vertexai.utils.timer import Timer
-from aidial_adapter_vertexai.vertex_ai import (
-    get_image_generation_model,
-    init_vertex_ai,
-)
+from aidial_adapter_vertexai.vertex_ai import get_image_generation_model
 
 ImagenPrompt = str
 
@@ -135,6 +132,5 @@ class ImagenChatCompletionAdapter(ChatCompletionAdapter[ImagenPrompt]):
         project_id: str,
         location: str,
     ) -> "ImagenChatCompletionAdapter":
-        await init_vertex_ai(project_id, location)
         model = await get_image_generation_model(model_id)
         return cls(file_storage, model)

--- a/aidial_adapter_vertexai/embedding/multi_modal.py
+++ b/aidial_adapter_vertexai/embedding/multi_modal.py
@@ -34,10 +34,7 @@ from aidial_adapter_vertexai.embedding.types import (
 from aidial_adapter_vertexai.utils.concurrency import gather_sync
 from aidial_adapter_vertexai.utils.json import json_dumps_short
 from aidial_adapter_vertexai.utils.log_config import vertex_ai_logger as log
-from aidial_adapter_vertexai.vertex_ai import (
-    get_multi_modal_embedding_model,
-    init_vertex_ai,
-)
+from aidial_adapter_vertexai.vertex_ai import get_multi_modal_embedding_model
 
 # See the documentation: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/multimodal-embeddings-api
 
@@ -189,7 +186,6 @@ class MultiModalEmbeddingsAdapter(EmbeddingsAdapter):
         api_key: str,
     ) -> "EmbeddingsAdapter":
         storage = create_file_storage(api_key)
-        await init_vertex_ai(project_id, location)
         model = await get_multi_modal_embedding_model(model_id)
         return cls(
             model_id=model_id, model=model, api_key=api_key, storage=storage

--- a/aidial_adapter_vertexai/embedding/text.py
+++ b/aidial_adapter_vertexai/embedding/text.py
@@ -26,7 +26,6 @@ from aidial_adapter_vertexai.utils.log_config import vertex_ai_logger as log
 from aidial_adapter_vertexai.vertex_ai import (
     TextEmbeddingModel,
     get_text_embedding_model,
-    init_vertex_ai,
 )
 
 # See available task types at: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/text-embeddings-api#tasktype
@@ -164,7 +163,6 @@ class TextEmbeddingsAdapter(EmbeddingsAdapter):
         project_id: str,
         location: str,
     ) -> "EmbeddingsAdapter":
-        await init_vertex_ai(project_id, location)
         model = await get_text_embedding_model(model_id)
         return cls(model_id=model_id, model=model)
 

--- a/aidial_adapter_vertexai/utils/concurrency.py
+++ b/aidial_adapter_vertexai/utils/concurrency.py
@@ -5,6 +5,19 @@ from typing import Callable, List, TypeVar
 T = TypeVar("T")
 A = TypeVar("A")
 
+_single_thread_async_lock = asyncio.Lock()
+
+
+async def make_single_thread_async(func: Callable[[A], T], arg: A) -> T:
+    """
+    Function to run a synchronous function in separate thread,
+    but only one at a time.
+    """
+    async with _single_thread_async_lock:
+        with ThreadPoolExecutor() as executor:
+            loop = asyncio.get_event_loop()
+            return await loop.run_in_executor(executor, func, arg)
+
 
 async def make_async(func: Callable[[A], T], arg: A) -> T:
     with ThreadPoolExecutor() as executor:

--- a/aidial_adapter_vertexai/vertex_ai.py
+++ b/aidial_adapter_vertexai/vertex_ai.py
@@ -13,7 +13,7 @@ from aidial_adapter_vertexai.utils.concurrency import make_single_thread_async
 
 @cached()
 async def get_code_chat_model(model_id: str) -> CodeChatModel:
-    # TODO: We're using single trehaded async call, because
+    # TODO: We're using single threaded async call, because
     # calling `from_pretrained` in different threads cause deadlock
     # https://github.com/googleapis/python-aiplatform/issues/4342
     # When this issue is resolved, we use just `make_async`

--- a/aidial_adapter_vertexai/vertex_ai.py
+++ b/aidial_adapter_vertexai/vertex_ai.py
@@ -8,6 +8,7 @@ from vertexai.preview.language_models import (
 from vertexai.preview.vision_models import ImageGenerationModel
 from vertexai.vision_models import MultiModalEmbeddingModel
 
+from aidial_adapter_vertexai.deployments import ChatCompletionDeployment
 from aidial_adapter_vertexai.utils.concurrency import make_async
 
 
@@ -41,3 +42,18 @@ async def get_multi_modal_embedding_model(
 @cached()
 async def get_image_generation_model(model_id: str) -> ImageGenerationModel:
     return await make_async(ImageGenerationModel.from_pretrained, model_id)
+
+
+DEPLOYMENT_TO_CONSTRUCTOR = {
+    ChatCompletionDeployment.CHAT_BISON_1: ChatModel.from_pretrained,
+    ChatCompletionDeployment.CHAT_BISON_2: ChatModel.from_pretrained,
+    ChatCompletionDeployment.CHAT_BISON_2_32K: ChatModel.from_pretrained,
+    ChatCompletionDeployment.CODECHAT_BISON_1: CodeChatModel.from_pretrained,
+    ChatCompletionDeployment.CODECHAT_BISON_2: CodeChatModel.from_pretrained,
+    ChatCompletionDeployment.CODECHAT_BISON_2_32K: CodeChatModel.from_pretrained,
+    ChatCompletionDeployment.GEMINI_PRO_1: GenerativeModel,
+    ChatCompletionDeployment.GEMINI_PRO_VISION_1: GenerativeModel,
+    ChatCompletionDeployment.GEMINI_PRO_1_5: GenerativeModel,
+    ChatCompletionDeployment.GEMINI_FLASH_1_5: GenerativeModel,
+    ChatCompletionDeployment.IMAGEN_005: ImageGenerationModel.from_pretrained,
+}

--- a/aidial_adapter_vertexai/vertex_ai.py
+++ b/aidial_adapter_vertexai/vertex_ai.py
@@ -1,4 +1,3 @@
-import vertexai
 from aiocache import cached
 from vertexai.preview.generative_models import GenerativeModel
 from vertexai.preview.language_models import (
@@ -10,15 +9,6 @@ from vertexai.preview.vision_models import ImageGenerationModel
 from vertexai.vision_models import MultiModalEmbeddingModel
 
 from aidial_adapter_vertexai.utils.concurrency import make_async
-
-
-# TODO: For now assume that there will be only one project and location.
-# We need to fix it otherwise.
-@cached()
-async def init_vertex_ai(project_id: str, location: str) -> None:
-    await make_async(
-        lambda _: vertexai.init(project=project_id, location=location), ()
-    )
 
 
 @cached()

--- a/aidial_adapter_vertexai/vertex_ai.py
+++ b/aidial_adapter_vertexai/vertex_ai.py
@@ -8,52 +8,48 @@ from vertexai.preview.language_models import (
 from vertexai.preview.vision_models import ImageGenerationModel
 from vertexai.vision_models import MultiModalEmbeddingModel
 
-from aidial_adapter_vertexai.deployments import ChatCompletionDeployment
-from aidial_adapter_vertexai.utils.concurrency import make_async
+from aidial_adapter_vertexai.utils.concurrency import make_single_thread_async
 
 
 @cached()
 async def get_code_chat_model(model_id: str) -> CodeChatModel:
-    return await make_async(CodeChatModel.from_pretrained, model_id)
+    # TODO: We're using single trehaded async call, because
+    # calling `from_pretrained` in different threads cause deadlock
+    # https://github.com/googleapis/python-aiplatform/issues/4342
+    # When this issue is resolved, we use just `make_async`
+    return await make_single_thread_async(
+        CodeChatModel.from_pretrained, model_id
+    )
 
 
 @cached()
 async def get_chat_model(model_id: str) -> ChatModel:
-    return await make_async(ChatModel.from_pretrained, model_id)
+    return await make_single_thread_async(ChatModel.from_pretrained, model_id)
 
 
 @cached()
 async def get_gemini_model(model_id: str) -> GenerativeModel:
-    return await make_async(GenerativeModel, model_id)
+    return await make_single_thread_async(GenerativeModel, model_id)
 
 
 @cached()
 async def get_text_embedding_model(model_id: str) -> TextEmbeddingModel:
-    return await make_async(TextEmbeddingModel.from_pretrained, model_id)
+    return await make_single_thread_async(
+        TextEmbeddingModel.from_pretrained, model_id
+    )
 
 
 @cached()
 async def get_multi_modal_embedding_model(
     model_id: str,
 ) -> MultiModalEmbeddingModel:
-    return await make_async(MultiModalEmbeddingModel.from_pretrained, model_id)
+    return await make_single_thread_async(
+        MultiModalEmbeddingModel.from_pretrained, model_id
+    )
 
 
 @cached()
 async def get_image_generation_model(model_id: str) -> ImageGenerationModel:
-    return await make_async(ImageGenerationModel.from_pretrained, model_id)
-
-
-DEPLOYMENT_TO_CONSTRUCTOR = {
-    ChatCompletionDeployment.CHAT_BISON_1: ChatModel.from_pretrained,
-    ChatCompletionDeployment.CHAT_BISON_2: ChatModel.from_pretrained,
-    ChatCompletionDeployment.CHAT_BISON_2_32K: ChatModel.from_pretrained,
-    ChatCompletionDeployment.CODECHAT_BISON_1: CodeChatModel.from_pretrained,
-    ChatCompletionDeployment.CODECHAT_BISON_2: CodeChatModel.from_pretrained,
-    ChatCompletionDeployment.CODECHAT_BISON_2_32K: CodeChatModel.from_pretrained,
-    ChatCompletionDeployment.GEMINI_PRO_1: GenerativeModel,
-    ChatCompletionDeployment.GEMINI_PRO_VISION_1: GenerativeModel,
-    ChatCompletionDeployment.GEMINI_PRO_1_5: GenerativeModel,
-    ChatCompletionDeployment.GEMINI_FLASH_1_5: GenerativeModel,
-    ChatCompletionDeployment.IMAGEN_005: ImageGenerationModel.from_pretrained,
-}
+    return await make_single_thread_async(
+        ImageGenerationModel.from_pretrained, model_id
+    )


### PR DESCRIPTION
Currently we can't use `make_async` due to this issue, that causes deadlock:
https://github.com/googleapis/python-aiplatform/issues/4342

Also created feature request for async version of `from_pretrained`:
https://github.com/googleapis/python-aiplatform/issues/4343