### PR TITLE
fix: fixed incorrect handling of multi-input embedding request

### DIFF
--- a/aidial_adapter_vertexai/embedding/multi_modal.py
+++ b/aidial_adapter_vertexai/embedding/multi_modal.py
@@ -203,8 +203,8 @@ class MultiModalEmbeddingsAdapter(EmbeddingsAdapter):
         tasks: List[Callable[[], Tuple[Embedding, int]]] = []
         async for sub_request in await get_requests(request, self.storage):
             tasks.append(
-                lambda: compute_embeddings(
-                    sub_request,
+                lambda sub_req=sub_request: compute_embeddings(
+                    sub_req,
                     self.model,
                     base64_encode=base64_encode,
                     dimensions=request.dimensions,


### PR DESCRIPTION
The bug manifested itself as repeating the embeddings for the very last input:

```
embeddings([input1, input2, input3]) = [vec3, vec3, vec3]
```

See the official [FAQ](https://docs.python.org/3/faq/programming.html#why-do-lambdas-defined-in-a-loop-with-different-values-all-return-the-same-result) re this classic Python pitfall.