### PR TITLE
fix: fixed bug in truncate prompt

### DIFF
--- a/aidial_adapter_vertexai/chat/bison/base.py
+++ b/aidial_adapter_vertexai/chat/bison/base.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import AsyncIterator, List, Tuple
+from typing import AsyncIterator, List
 
 from aidial_sdk.chat_completion import FinishReason, Message
 from typing_extensions import override
@@ -15,7 +15,7 @@ from aidial_adapter_vertexai.chat.chat_completion_adapter import (
 )
 from aidial_adapter_vertexai.chat.consumer import Consumer
 from aidial_adapter_vertexai.chat.tools import ToolsConfig
-from aidial_adapter_vertexai.chat.truncate_prompt import DiscardedMessages
+from aidial_adapter_vertexai.chat.truncate_prompt import TruncatedPrompt
 from aidial_adapter_vertexai.dial_api.request import ModelParameters
 from aidial_adapter_vertexai.dial_api.token_usage import TokenUsage
 from aidial_adapter_vertexai.utils.log_config import vertex_ai_logger as log
@@ -44,7 +44,7 @@ class BisonChatCompletionAdapter(ChatCompletionAdapter[BisonPrompt]):
     @override
     async def truncate_prompt(
         self, prompt: BisonPrompt, max_prompt_tokens: int
-    ) -> Tuple[DiscardedMessages, BisonPrompt]:
+    ) -> TruncatedPrompt[BisonPrompt]:
         return await prompt.truncate(
             tokenizer=self.count_prompt_tokens, user_limit=max_prompt_tokens
         )

--- a/aidial_adapter_vertexai/chat/chat_completion_adapter.py
+++ b/aidial_adapter_vertexai/chat/chat_completion_adapter.py
@@ -1,12 +1,12 @@
 from abc import ABC, abstractmethod
-from typing import Generic, List, Tuple, TypeVar
+from typing import Generic, List, TypeVar
 
 from aidial_sdk.chat_completion import Message
 
 from aidial_adapter_vertexai.chat.consumer import Consumer
 from aidial_adapter_vertexai.chat.errors import UserError
 from aidial_adapter_vertexai.chat.tools import ToolsConfig
-from aidial_adapter_vertexai.chat.truncate_prompt import DiscardedMessages
+from aidial_adapter_vertexai.chat.truncate_prompt import TruncatedPrompt
 from aidial_adapter_vertexai.dial_api.request import ModelParameters
 from aidial_adapter_vertexai.utils.not_implemented import not_implemented
 
@@ -29,7 +29,7 @@ class ChatCompletionAdapter(ABC, Generic[P]):
     @not_implemented
     async def truncate_prompt(
         self, prompt: P, max_prompt_tokens: int
-    ) -> Tuple[DiscardedMessages, P]: ...
+    ) -> TruncatedPrompt: ...
 
     @not_implemented
     async def count_prompt_tokens(self, prompt: P) -> int: ...

--- a/aidial_adapter_vertexai/chat/gemini/adapter.py
+++ b/aidial_adapter_vertexai/chat/gemini/adapter.py
@@ -6,7 +6,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Tuple,
     TypeVar,
     assert_never,
     cast,
@@ -43,7 +42,7 @@ from aidial_adapter_vertexai.chat.gemini.prompt.gemini_1_5 import (
     Gemini_1_5_Prompt,
 )
 from aidial_adapter_vertexai.chat.tools import ToolsConfig
-from aidial_adapter_vertexai.chat.truncate_prompt import DiscardedMessages
+from aidial_adapter_vertexai.chat.truncate_prompt import TruncatedPrompt
 from aidial_adapter_vertexai.deployments import (
     ChatCompletionDeployment,
     GeminiDeployment,
@@ -228,7 +227,7 @@ class GeminiChatCompletionAdapter(ChatCompletionAdapter[GeminiPrompt]):
     @override
     async def truncate_prompt(
         self, prompt: GeminiPrompt, max_prompt_tokens: int
-    ) -> Tuple[DiscardedMessages, GeminiPrompt]:
+    ) -> TruncatedPrompt[GeminiPrompt]:
         return await prompt.truncate(
             tokenizer=self.count_prompt_tokens, user_limit=max_prompt_tokens
         )

--- a/aidial_adapter_vertexai/chat/imagen/adapter.py
+++ b/aidial_adapter_vertexai/chat/imagen/adapter.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from aidial_sdk.chat_completion import Attachment, Message
 from PIL import Image as PIL_Image
@@ -15,7 +15,7 @@ from aidial_adapter_vertexai.chat.chat_completion_adapter import (
 from aidial_adapter_vertexai.chat.consumer import Consumer
 from aidial_adapter_vertexai.chat.errors import ValidationError
 from aidial_adapter_vertexai.chat.tools import ToolsConfig
-from aidial_adapter_vertexai.chat.truncate_prompt import DiscardedMessages
+from aidial_adapter_vertexai.chat.truncate_prompt import TruncatedPrompt
 from aidial_adapter_vertexai.dial_api.request import (
     ModelParameters,
     collect_text_content,
@@ -59,8 +59,8 @@ class ImagenChatCompletionAdapter(ChatCompletionAdapter[ImagenPrompt]):
     @override
     async def truncate_prompt(
         self, prompt: ImagenPrompt, max_prompt_tokens: int
-    ) -> Tuple[DiscardedMessages, ImagenPrompt]:
-        return [], prompt
+    ) -> TruncatedPrompt[ImagenPrompt]:
+        return TruncatedPrompt(discarded_messages=[], prompt=prompt)
 
     @staticmethod
     def get_image_type(image: PIL_Image.Image) -> str:

--- a/aidial_adapter_vertexai/chat_completion.py
+++ b/aidial_adapter_vertexai/chat_completion.py
@@ -30,6 +30,7 @@ from aidial_adapter_vertexai.chat.chat_completion_adapter import (
 from aidial_adapter_vertexai.chat.consumer import ChoiceConsumer
 from aidial_adapter_vertexai.chat.errors import UserError, ValidationError
 from aidial_adapter_vertexai.chat.tools import ToolsConfig
+from aidial_adapter_vertexai.chat.truncate_prompt import DiscardedMessages
 from aidial_adapter_vertexai.deployments import ChatCompletionDeployment
 from aidial_adapter_vertexai.dial_api.exceptions import dial_exception_decorator
 from aidial_adapter_vertexai.dial_api.request import ModelParameters
@@ -69,14 +70,14 @@ class VertexAIChatCompletion(ChatCompletion):
         if n > 1 and params.stream:
             raise ValidationError("n>1 is not supported in streaming mode")
 
-        discarded_messages: List[int] = []
+        discarded_messages: DiscardedMessages = []
         if params.max_prompt_tokens is not None:
             if not is_implemented(model.truncate_prompt):
                 raise ValidationError(
                     "max_prompt_tokens request parameter is not supported"
                 )
 
-            prompt, discarded_messages = await model.truncate_prompt(
+            discarded_messages, prompt = await model.truncate_prompt(
                 prompt, params.max_prompt_tokens
             )
 

--- a/aidial_adapter_vertexai/chat_completion.py
+++ b/aidial_adapter_vertexai/chat_completion.py
@@ -26,11 +26,11 @@ from typing_extensions import override
 from aidial_adapter_vertexai.adapters import get_chat_completion_model
 from aidial_adapter_vertexai.chat.chat_completion_adapter import (
     ChatCompletionAdapter,
+    TruncatedPrompt,
 )
 from aidial_adapter_vertexai.chat.consumer import ChoiceConsumer
 from aidial_adapter_vertexai.chat.errors import UserError, ValidationError
 from aidial_adapter_vertexai.chat.tools import ToolsConfig
-from aidial_adapter_vertexai.chat.truncate_prompt import DiscardedMessages
 from aidial_adapter_vertexai.deployments import ChatCompletionDeployment
 from aidial_adapter_vertexai.dial_api.exceptions import dial_exception_decorator
 from aidial_adapter_vertexai.dial_api.request import ModelParameters
@@ -70,14 +70,16 @@ class VertexAIChatCompletion(ChatCompletion):
         if n > 1 and params.stream:
             raise ValidationError("n>1 is not supported in streaming mode")
 
-        discarded_messages: DiscardedMessages = []
-        if params.max_prompt_tokens is not None:
+        if params.max_prompt_tokens is None:
+            truncated_prompt = TruncatedPrompt(
+                prompt=prompt, discarded_messages=[]
+            )
+        else:
             if not is_implemented(model.truncate_prompt):
                 raise ValidationError(
                     "max_prompt_tokens request parameter is not supported"
                 )
-
-            discarded_messages, prompt = await model.truncate_prompt(
+            truncated_prompt = await model.truncate_prompt(
                 prompt, params.max_prompt_tokens
             )
 
@@ -86,7 +88,7 @@ class VertexAIChatCompletion(ChatCompletion):
             choice.open()
 
             consumer = ChoiceConsumer(choice)
-            await model.chat(params, consumer, prompt)
+            await model.chat(params, consumer, truncated_prompt.prompt)
             usage.accumulate(consumer.usage)
 
             finish_reason = consumer.finish_reason
@@ -103,7 +105,7 @@ class VertexAIChatCompletion(ChatCompletion):
         response.set_usage(usage.prompt_tokens, usage.completion_tokens)
 
         if params.max_prompt_tokens is not None:
-            response.set_discarded_messages(discarded_messages)
+            response.set_discarded_messages(truncated_prompt.discarded_messages)
 
     @override
     @dial_exception_decorator
@@ -175,9 +177,14 @@ class VertexAIChatCompletion(ChatCompletion):
             if request.max_prompt_tokens is None:
                 raise ValidationError("max_prompt_tokens is required")
 
-            discarded_messages, _prompt = await model.truncate_prompt(
-                request.messages, request.max_prompt_tokens
+            tools = ToolsConfig.from_request(request)
+            prompt = await model.parse_prompt(tools, request.messages)
+
+            truncated_prompt = await model.truncate_prompt(
+                prompt, request.max_prompt_tokens
             )
-            return TruncatePromptSuccess(discarded_messages=discarded_messages)
+            return TruncatePromptSuccess(
+                discarded_messages=truncated_prompt.discarded_messages
+            )
         except Exception as e:
             return TruncatePromptError(error=str(e))

--- a/tests/unit_tests/prompt_truncation/utils.py
+++ b/tests/unit_tests/prompt_truncation/utils.py
@@ -15,4 +15,4 @@ async def get_discarded_messages(
 ) -> DiscardedMessages:
     return (
         await prompt.truncate(tokenizer=tokenizer, user_limit=max_prompt_tokens)
-    )[0]
+    ).discarded_messages


### PR DESCRIPTION
The bug manifests itself as the error:

```json
{
  "error": {
    "message": "'list' object has no attribute 'tools'",
    "type": "internal_server_error",
    "code": "500"
  }
}
```

in response to a request with `max_prompt_tokens != None`.