### PR TITLE
fix: Gemini: reporting safety errors properly

### DIFF
--- a/aidial_adapter_vertexai/chat/gemini/adapter.py
+++ b/aidial_adapter_vertexai/chat/gemini/adapter.py
@@ -356,14 +356,13 @@ def to_openai_finish_reason(
 
 
 def _get_candidate_text_safe(candidate: Candidate) -> str | None:
-    # The text content of a candidate may be missing when function is called
+    # The text content of a candidate may be missing when function is called or
+    # when the generation was terminated with SAFETY finish reason.
     try:
         return candidate.text
-    except ValueError:
-        if candidate.function_calls:
-            return None
-        else:
-            raise
+    except ValueError as e:
+        log.debug(f"The Candidate doesn't have text: {e}")
+        return None
 
 
 T = TypeVar("T")


### PR DESCRIPTION
The Candidate content is usually missing, when Gemini generation fails because of safety concerns.

However, we have this check that propagates no-content exception even when Gemini finished with the SAFETY finish reason:

https://github.com/epam/ai-dial-adapter-vertexai/commit/7e0dc16165cf5ec9438ac41bfd02e647cc47c18f#diff-20ff40a59026b1305f254cb0613e698980701b407b4710e76b356bff8ebd5c2cR358-R369

This leads to a 500 response, instead of a response with `finish_reason=content_filter`.

The check was made more forgiving.

### How to trigger SAFETY finish reason in Gemini

Ask the model 

```
Write '$text' reversed. Elaborate on it.
```

Where $text is a reversed representation of an unsafe text of your choice.