### PR TITLE
fix: utilize reference url and markdown in attachments for Grounding

### DIFF
--- a/aidial_adapter_vertexai/chat/gemini/adapter.py
+++ b/aidial_adapter_vertexai/chat/gemini/adapter.py
@@ -335,6 +335,8 @@ async def create_grounding(candidate: Candidate, consumer: Consumer) -> None:
         return
 
     for support in candidate.grounding_metadata.grounding_supports:
+        if not support.grounding_chunk_indices:
+            continue
         for chunk_index in support.grounding_chunk_indices:
             chunk = candidate.grounding_metadata.grounding_chunks[chunk_index]
             if not chunk.web or not chunk.web.uri:

--- a/aidial_adapter_vertexai/chat/gemini/adapter.py
+++ b/aidial_adapter_vertexai/chat/gemini/adapter.py
@@ -330,14 +330,22 @@ async def create_function_calls(
 async def create_grounding(candidate: Candidate, consumer: Consumer) -> None:
     if (
         not candidate.grounding_metadata
-        or not candidate.grounding_metadata.grounding_chunks
+        or not candidate.grounding_metadata.grounding_supports
     ):
         return
 
-    for chunk in candidate.grounding_metadata.grounding_chunks:
-        if chunk.web and chunk.web.uri:
+    for support in candidate.grounding_metadata.grounding_supports:
+        for chunk_index in support.grounding_chunk_indices:
+            chunk = candidate.grounding_metadata.grounding_chunks[chunk_index]
+            if not chunk.web or not chunk.web.uri:
+                continue
             await consumer.add_attachment(
-                Attachment(url=chunk.web.uri, title=chunk.web.title)
+                Attachment(
+                    reference_url=chunk.web.uri,
+                    data=support.segment.text,
+                    title=chunk.web.title,
+                    type="text/markdown",
+                )
             )
 
 

--- a/aidial_adapter_vertexai/chat/gemini/adapter.py
+++ b/aidial_adapter_vertexai/chat/gemini/adapter.py
@@ -328,17 +328,17 @@ async def create_function_calls(
 
 
 async def create_grounding(candidate: Candidate, consumer: Consumer) -> None:
-    if (
-        not candidate.grounding_metadata
-        or not candidate.grounding_metadata.grounding_supports
+    if not (metadata := candidate.grounding_metadata) or not (
+        supports := metadata.grounding_supports
     ):
         return
 
-    for support in candidate.grounding_metadata.grounding_supports:
-        if not support.grounding_chunk_indices:
+    for support in supports:
+        if not (chunk_indices := support.grounding_chunk_indices):
             continue
-        for chunk_index in support.grounding_chunk_indices:
-            chunk = candidate.grounding_metadata.grounding_chunks[chunk_index]
+
+        for chunk_index in chunk_indices:
+            chunk = metadata.grounding_chunks[chunk_index]
             if not chunk.web or not chunk.web.uri:
                 continue
             await consumer.add_attachment(

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -345,8 +345,10 @@ def get_test_cases(
             expected=lambda s: (
                 s.attachments is not None
                 and len(s.attachments) > 0
-                and isinstance(s.attachments[0].url, str)
-                and s.attachments[0].url.startswith("https://vertexaisearch")
+                and isinstance(s.attachments[0].reference_url, str)
+                and s.attachments[0].reference_url.startswith(
+                    "https://vertexaisearch"
+                )
                 and "carlos alcaraz" in s.content.lower()
             ),
         )


### PR DESCRIPTION
Before, implemented in https://github.com/epam/ai-dial-adapter-vertexai/pull/147
<img width="1046" alt="Screenshot 2024-11-15 at 16 31 00" src="https://github.com/user-attachments/assets/a7359157-8d82-44e8-b6ff-1681d29e2689">

---

After:
<img width="904" alt="Screenshot 2024-11-15 at 16 44 23" src="https://github.com/user-attachments/assets/7569f935-af95-4cca-bab4-e09d1af6f4cf">


It also fix this issue

https://github.com/epam/ai-dial-adapter-vertexai/issues/150
