### PR TITLE
chore: pinned Docker image to alpine-3.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine as builder
+FROM python:3.11-alpine3.20 as builder
 
 RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
 # geos-dev is required for https://pypi.org/project/shapely/2.0.5/
@@ -15,7 +15,7 @@ RUN poetry install --no-interaction --no-ansi --no-cache --no-root --no-director
 COPY . .
 RUN poetry install --no-interaction --no-ansi --no-cache --only main
 
-FROM python:3.11-alpine as server
+FROM python:3.11-alpine3.20 as server
 
 RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
 # fix CVE-2023-52425


### PR DESCRIPTION
1. `python:3.11-alpine` used to be based on `alpine:3.19` but the last week [switched](https://github.com/docker-library/python/commit/3d7b328b66525fe2e82af7063af10c176b6ee8cd#diff-e9b53fe2eb57e3841a48b1b2a8788ebd6e95b2f565aca0a6768b734db9267c64L7) to `alpine:3.21`
2. `alpine:3.19` depends on `gcc 13.2.1`, whereas `alpine:3.21` depends on `gcc 14.2.0`
3. `shapely` package [fails](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1075423) to compile under `gcc 14.*`
4. the bug is known and the bugfix is expected to be [delivered](https://github.com/shapely/shapely/issues/2081#issuecomment-2350141983) in `shapely=2.1.0`
5. until then we need to go back to the apline with gcc version that is able to compile `sharely` without errors - `alpine:3.20`