### PR TITLE
fix: gemini: fixed bug in a finish reason handler

### DIFF
--- a/aidial_adapter_vertexai/chat/gemini/adapter.py
+++ b/aidial_adapter_vertexai/chat/gemini/adapter.py
@@ -90,9 +90,9 @@ def create_generation_config(params: ModelParameters) -> GenerationConfig:
 
 class FinishReasonOtherError(Exception):
     def __init__(self, msg: str, retriable: bool):
-        super().__init__(self.msg)
         self.msg = msg
         self.retriable = retriable
+        super().__init__(self.msg)
 
 
 class GeminiChatCompletionAdapter(ChatCompletionAdapter[GeminiPrompt]):


### PR DESCRIPTION
The `FinishReasonOtherError` ctor fails with the error:

```
Upstream: http://vertexai-adapter:5000/openai/deployments/gemini-1.5-flash-002/chat/completions. Status: 200. Headers: 4
vertexai-adapter-1                 | ERROR:    | 2024-12-20 09:33:20 | 1 | app | caught exception: builtins.AttributeError
vertexai-adapter-1                 | Traceback (most recent call last):
vertexai-adapter-1                 |   File "/app/aidial_adapter_vertexai/dial_api/exceptions.py", line 72, in wrapper
vertexai-adapter-1                 |     return await func(*args, **kwargs)
vertexai-adapter-1                 |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
vertexai-adapter-1                 |   File "/app/aidial_adapter_vertexai/chat_completion.py", line 107, in chat_completion
vertexai-adapter-1                 |     await asyncio.gather(
vertexai-adapter-1                 |   File "/app/aidial_adapter_vertexai/chat_completion.py", line 97, in generate_response
vertexai-adapter-1                 |     await model.chat(params, consumer, truncated_prompt.prompt)
vertexai-adapter-1                 |   File "/app/aidial_adapter_vertexai/chat/gemini/adapter.py", line 237, in chat
vertexai-adapter-1                 |     async for content in generate_with_retries(
vertexai-adapter-1                 |   File "/app/aidial_adapter_vertexai/chat/gemini/adapter.py", line 405, in generate_with_retries
vertexai-adapter-1                 |     async for content in generator():
vertexai-adapter-1                 |   File "/app/aidial_adapter_vertexai/chat/gemini/adapter.py", line 210, in process_chunks
vertexai-adapter-1                 |     await set_finish_reason(candidate, consumer)
vertexai-adapter-1                 |   File "/app/aidial_adapter_vertexai/chat/gemini/adapter.py", line 284, in set_finish_reason
vertexai-adapter-1                 |     openai_reason = to_openai_finish_reason(
vertexai-adapter-1                 |                     ^^^^^^^^^^^^^^^^^^^^^^^^
vertexai-adapter-1                 |   File "/app/aidial_adapter_vertexai/chat/gemini/adapter.py", line 378, in to_openai_finish_reason
vertexai-adapter-1                 |     raise FinishReasonOtherError(
vertexai-adapter-1                 |           ^^^^^^^^^^^^^^^^^^^^^^^
vertexai-adapter-1                 |   File "/app/aidial_adapter_vertexai/chat/gemini/adapter.py", line 93, in __init__
vertexai-adapter-1                 |     super().__init__(self.msg)
vertexai-adapter-1                 |                      ^^^^^^^^
vertexai-adapter-1                 | AttributeError: 'FinishReasonOtherError' object has no attribute 'msg'
``` 