### PR TITLE
fix: Fix error message if there is empty string in Gemini message

### DIFF
--- a/aidial_adapter_vertexai/chat/gemini/inputs.py
+++ b/aidial_adapter_vertexai/chat/gemini/inputs.py
@@ -89,7 +89,7 @@ async def _message_to_gemini_parts(
             return await processors.process_message(message)
 
         case Role.USER:
-            if content is None:
+            if not content:
                 raise ValidationError("User message content must be present")
             return await processors.process_message(message)
 
@@ -99,7 +99,7 @@ async def _message_to_gemini_parts(
             elif message.tool_calls is not None:
                 return [tool_call_to_part(call) for call in message.tool_calls]
             else:
-                if content is None:
+                if not content:
                     raise ValidationError(
                         "Assistant message content must be present"
                     )

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -22,6 +22,7 @@ from tests.utils.openai import (
     GET_WEATHER_FUNCTION,
     GET_WEATHER_TOOL,
     ChatCompletionResult,
+    ai,
     ai_function,
     ai_tools,
     blue_pic,
@@ -149,6 +150,14 @@ def supports_text_input(deployment: ChatCompletionDeployment) -> bool:
     return deployment != ChatCompletionDeployment.GEMINI_PRO_VISION_1
 
 
+def supports_empty_content(deployment: ChatCompletionDeployment) -> bool:
+    return is_codechat(deployment) or deployment in [
+        ChatCompletionDeployment.CHAT_BISON_1,
+        ChatCompletionDeployment.CHAT_BISON_2,
+        ChatCompletionDeployment.CHAT_BISON_2_32K,
+    ]
+
+
 def is_vision_model(deployment: ChatCompletionDeployment) -> bool:
     return deployment in [
         ChatCompletionDeployment.GEMINI_PRO_VISION_1,
@@ -215,6 +224,33 @@ def get_test_cases(
             messages=[sys("Act as helpful assistant"), user("2+5=?")],
             expected=for_all_choices(lambda s: "7" in s),
         )
+
+        if not supports_empty_content(deployment):
+            test_case(
+                name="empty assistant content",
+                messages=[
+                    user("hi, what is your name?"),
+                    ai(""),
+                    user("please come again?"),
+                ],
+                expected=ExpectedException(
+                    type=UnprocessableEntityError,
+                    message="Assistant message content must be present",
+                    status_code=422,
+                ),
+            )
+
+            test_case(
+                name="empty user content",
+                messages=[
+                    user(""),
+                ],
+                expected=ExpectedException(
+                    type=UnprocessableEntityError,
+                    message="User message content must be present",
+                    status_code=422,
+                ),
+            )
 
         test_case(
             name="max tokens 1",

--- a/tests/integration_tests/test_chat_completion.py
+++ b/tests/integration_tests/test_chat_completion.py
@@ -225,32 +225,39 @@ def get_test_cases(
             expected=for_all_choices(lambda s: "7" in s),
         )
 
-        if not supports_empty_content(deployment):
-            test_case(
-                name="empty assistant content",
-                messages=[
-                    user("hi, what is your name?"),
-                    ai(""),
-                    user("please come again?"),
-                ],
-                expected=ExpectedException(
+        test_case(
+            name="empty assistant content",
+            messages=[
+                user("hi, what is your name?"),
+                ai(""),
+                user("please come again?"),
+            ],
+            expected=(
+                expected_success
+                if supports_empty_content(deployment)
+                else ExpectedException(
                     type=UnprocessableEntityError,
                     message="Assistant message content must be present",
                     status_code=422,
-                ),
-            )
+                )
+            ),
+        )
 
-            test_case(
-                name="empty user content",
-                messages=[
-                    user(""),
-                ],
-                expected=ExpectedException(
+        test_case(
+            name="empty user content",
+            messages=[
+                user(""),
+            ],
+            expected=(
+                expected_success
+                if supports_empty_content(deployment)
+                else ExpectedException(
                     type=UnprocessableEntityError,
                     message="User message content must be present",
                     status_code=422,
-                ),
-            )
+                )
+            ),
+        )
 
         test_case(
             name="max tokens 1",


### PR DESCRIPTION
Currently if user will send messages like this (which is possible in chat if we stop model generation right after the first message, and run one more query after it)
```json
{
  "messages": [
    {
      "content": "hi, what's your name?",
      "role": "user"
    },
    {
      "content": "",
      "role": "assistant"
    },
    {
      "content": "please come again?",
      "role": "user"
    }
  ]
}
```

Response is
```json
{"error":{"message":"{\"error\":{\"message\":\"Invalid argument: 400 Unable to submit request because it must include at least one parts field, which describes the prompt input. Learn more: [https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini\",\"type\":\"invalid_request_error\",\"code\":\"400\"}}","type":"runtime_error","code":"400"}}](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini/%22,/%22type/%22:/%22invalid_request_error/%22,/%22code/%22:/%22400/%22%7D%7D%22,%22type%22:%22runtime_error%22,%22code%22:%22400%22%7D%7D)
```

---

Changed it to same `ValidationError("System message content must be present")` / `ValidationError("User message content must be present")` which we raise if content is `None`
