### PR TITLE
chore: add gemini-2.0-flash-001 to the list of supported models in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ The following models support `POST SERVER_URL/openai/deployments/DEPLOYMENT_NAME
 |---|---|---|---|---|---|
 |Gemini 2.0 Pro|gemini-2.0-pro-exp-02-05|(text/pdf/image/audio/video)-to-text|✅|✅|✅|
 |Gemini 2.0 Flash Thinking|gemini-2.0-flash-thinking-exp-01-21|text-to-text|✅|✅|❌|
-|Gemini 2.0 Flash|gemini-2.0-flash-exp|(text/pdf/image/audio/video)-to-text|✅|✅|✅|
+|Gemini 2.0 Flash|gemini-2.0-flash-(exp\|001)|(text/pdf/image/audio/video)-to-text|✅|✅|✅|
 |Gemini 2.0 Flash Lite|gemini-2.0-flash-lite-preview-02-05|(text/pdf/image/audio/video)-to-text|✅|✅|❌|
-|Gemini 1.5 Pro|gemini-1.5-pro-[preview-0409\|001\|002]|(text/pdf/image/audio/video)-to-text|✅|✅|✅|
-|Gemini 1.5 Flash|gemini-1.5-flash-[001\|002]|(text/pdf/image/audio/video)-to-text|✅|✅|✅|
+|Gemini 1.5 Pro|gemini-1.5-pro-(preview-0409\|001\|002)|(text/pdf/image/audio/video)-to-text|✅|✅|✅|
+|Gemini 1.5 Flash|gemini-1.5-flash-(001\|002)|(text/pdf/image/audio/video)-to-text|✅|✅|✅|
 |Gemini 1.0 Pro Vision|gemini-pro-vision|(text/pdf/image/video)-to-text|✅|✅|❌|
 |Gemini 1.0 Pro|gemini-pro|text-to-text|✅|✅|✅|
 |Claude 3 Opus|claude-3-opus@20240229|(text/image)-to-text|✅|✅|✅|


### PR DESCRIPTION
It's follow up for https://github.com/epam/ai-dial-adapter-vertexai/pull/190 where the README wasn't updated.