### PR TITLE
fix: Gemini 1.5 with google grounding

### DIFF
--- a/aidial_adapter_vertexai/chat/gemini/adapter/genai_lib.py
+++ b/aidial_adapter_vertexai/chat/gemini/adapter/genai_lib.py
@@ -116,9 +116,11 @@ class GeminiGenAIChatCompletionAdapter(
     async def send_message_async(
         self, params: ModelParameters, prompt: GeminiGenAIPrompt
     ) -> AsyncIterator[GenAIGenerateContentResponse]:
+        is_gemini_1_5 = isinstance(prompt, Gemini_1_5_Prompt)
 
         generation_config = create_genai_generation_config(
             params,
+            is_gemini_1_5,
             prompt.tools,
             prompt.static_tools,
             prompt.system_instruction,

--- a/aidial_adapter_vertexai/chat/gemini/generation_config.py
+++ b/aidial_adapter_vertexai/chat/gemini/generation_config.py
@@ -39,6 +39,7 @@ def create_generation_config(params: ModelParameters) -> GenerationConfig:
 
 def create_genai_generation_config(
     params: ModelParameters,
+    is_gemini_1_5: bool,
     tools: ToolsConfig,
     static_tools: StaticToolsConfig,
     system_instruction: List[GenAIPart] | None = None,
@@ -52,7 +53,7 @@ def create_genai_generation_config(
     elif not tools.is_empty():
         genai_tools = tools.to_gemini_genai_tools()
     elif not static_tools.is_empty():
-        genai_tools = static_tools.to_gemini_genai_tools()
+        genai_tools = static_tools.to_gemini_genai_tools(is_gemini_1_5)
 
     response_mime_type, response_schema = _get_response_format(params)
 

--- a/aidial_adapter_vertexai/chat/static_tools.py
+++ b/aidial_adapter_vertexai/chat/static_tools.py
@@ -6,6 +6,7 @@ from aidial_sdk.chat_completion.request import (
     StaticFunction,
     StaticTool,
 )
+from google.genai.types import GoogleSearchDict as GenAIGoogleSearch
 from google.genai.types import ToolDict as GenAITool
 from pydantic.v1 import BaseModel, ConstrainedFloat, Field
 from pydantic.v1 import ValidationError as PydanticValidationError
@@ -96,15 +97,15 @@ class GenAIGoogleSearchTool:
         static_function: StaticFunction,
     ) -> List[GenAITool] | None:
         if static_function.name == ToolName.GOOGLE_SEARCH:
-            config = static_function.configuration or {}
+            config = static_function.configuration
             if is_gemini_1_5:
                 return [GenAITool(google_search_retrieval=config)]  # type: ignore
             else:
                 if config:
                     raise ValidationError(
-                        "Google search tool configuration is not supported"
+                        "Model doesn't support configuration for Google search tool"
                     )
-                return [GenAITool(google_search={})]
+                return [GenAITool(google_search=GenAIGoogleSearch())]
         return None
 
 

--- a/aidial_adapter_vertexai/chat/static_tools.py
+++ b/aidial_adapter_vertexai/chat/static_tools.py
@@ -1,6 +1,5 @@
-from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Generic, List, Literal, NoReturn, Self, TypeVar
+from typing import List, Literal, NoReturn, Self
 
 from aidial_sdk.chat_completion.request import (
     AzureChatCompletionRequest,
@@ -18,18 +17,8 @@ from aidial_adapter_vertexai.chat.errors import ValidationError
 
 class ToolName(str, Enum):
     # https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/grounding
+    # https://ai.google.dev/gemini-api/docs/grounding?lang=python#google-search-retrieval
     GOOGLE_SEARCH = "google_search"
-
-
-ToolT = TypeVar("ToolT")
-
-
-class StaticToolProcessor(ABC, Generic[ToolT]):
-    @staticmethod
-    @abstractmethod
-    def parse_gemini_tools(
-        static_function: StaticFunction,
-    ) -> List[ToolT] | None: ...
 
 
 class DynamicThreshold(ConstrainedFloat):
@@ -69,7 +58,7 @@ class GoogleSearchConfig(BaseModel):
     )
 
 
-class GoogleSearchGroundingTool(StaticToolProcessor[GeminiTool]):
+class GoogleSearchGroundingTool:
     @staticmethod
     def parse_gemini_tools(
         static_function: StaticFunction,
@@ -100,14 +89,22 @@ class GoogleSearchGroundingTool(StaticToolProcessor[GeminiTool]):
         return None
 
 
-class GenAIGoogleSearchTool(StaticToolProcessor[GenAITool]):
+class GenAIGoogleSearchTool:
     @staticmethod
     def parse_gemini_tools(
+        is_gemini_1_5: bool,
         static_function: StaticFunction,
     ) -> List[GenAITool] | None:
         if static_function.name == ToolName.GOOGLE_SEARCH:
             config = static_function.configuration or {}
-            return [GenAITool(google_search_retrieval=config)]  # type: ignore
+            if is_gemini_1_5:
+                return [GenAITool(google_search_retrieval=config)]  # type: ignore
+            else:
+                if config:
+                    raise ValidationError(
+                        "Google search tool configuration is not supported"
+                    )
+                return [GenAITool(google_search={})]
         return None
 
 
@@ -148,11 +145,11 @@ class StaticToolsConfig(BaseModel):
             )
         return ret
 
-    def to_gemini_genai_tools(self) -> List[GenAITool]:
+    def to_gemini_genai_tools(self, is_gemini_1_5: bool) -> List[GenAITool]:
         ret: List[GenAITool] = []
         for tool in self.functions:
             ret.extend(
-                GenAIGoogleSearchTool.parse_gemini_tools(tool)
+                GenAIGoogleSearchTool.parse_gemini_tools(is_gemini_1_5, tool)
                 or unknown_tool_name(tool)
             )
         return ret

--- a/aidial_adapter_vertexai/chat/static_tools.py
+++ b/aidial_adapter_vertexai/chat/static_tools.py
@@ -7,7 +7,6 @@ from aidial_sdk.chat_completion.request import (
     StaticFunction,
     StaticTool,
 )
-from google.genai.types import GoogleSearchDict as GenAIGoogleSearch
 from google.genai.types import ToolDict as GenAITool
 from pydantic.v1 import BaseModel, ConstrainedFloat, Field
 from pydantic.v1 import ValidationError as PydanticValidationError
@@ -107,12 +106,8 @@ class GenAIGoogleSearchTool(StaticToolProcessor[GenAITool]):
         static_function: StaticFunction,
     ) -> List[GenAITool] | None:
         if static_function.name == ToolName.GOOGLE_SEARCH:
-            if static_function.configuration:
-                raise ValidationError(
-                    "Model doesn't support configuration for Google search tool"
-                )
-            return [GenAITool(google_search=GenAIGoogleSearch())]
-
+            config = static_function.configuration or {}
+            return [GenAITool(google_search_retrieval=config)]  # type: ignore
         return None
 
 


### PR DESCRIPTION
Regression introduced by #210 

Gemini 1.5 with Google Grounding throws the error:

```
google.genai.errors.ClientError: 400 INVALID_ARGUMENT. 
{'error': {'code': 400, 'message': 'Unable to submit request because google_search is not supported; 
please use google_search_retrieval field instead. 
Learn more: [https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini'](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini%27), 
'status': 'INVALID_ARGUMENT'}}
```

Used `google_search_retrieval` for Gemini 1.5 models as per [doc](https://ai.google.dev/gemini-api/docs/grounding?lang=python#google-search-retrieval).