### PR TITLE
fix: Gemini: enable streaming

### DIFF
--- a/aidial_adapter_vertexai/chat/consumer.py
+++ b/aidial_adapter_vertexai/chat/consumer.py
@@ -15,45 +15,40 @@ from aidial_adapter_vertexai.dial_api.token_usage import TokenUsage
 
 class Consumer(ABC):
     @abstractmethod
-    async def append_content(self, content: str):
-        pass
+    async def append_content(self, content: str): ...
 
     @abstractmethod
-    async def create_function_call(self, name: str, arguments: str | None):
-        pass
+    async def create_function_call(self, name: str, arguments: str | None): ...
 
     @abstractmethod
-    async def create_tool_call(self, id: str, name: str, arguments: str | None):
-        pass
+    async def create_tool_call(
+        self, id: str, name: str, arguments: str | None
+    ): ...
 
     @abstractmethod
-    async def add_attachment(self, attachment: Attachment):
-        pass
+    async def add_attachment(self, attachment: Attachment): ...
 
     @abstractmethod
-    async def set_usage(self, usage: TokenUsage):
-        pass
+    async def set_usage(self, usage: TokenUsage): ...
 
     @abstractmethod
-    async def set_finish_reason(self, finish_reason: FinishReason):
-        pass
+    async def set_finish_reason(self, finish_reason: FinishReason): ...
 
     @abstractmethod
-    def get_finish_reason(self) -> FinishReason | None:
-        pass
+    def get_finish_reason(self) -> FinishReason | None: ...
 
     @abstractmethod
-    def is_empty(self) -> bool:
-        pass
+    def is_empty(self) -> bool: ...
 
     @abstractmethod
-    async def create_stage(self, name: str) -> Stage:
-        pass
+    async def aflush(self): ...
+
+    @abstractmethod
+    async def create_stage(self, name: str) -> Stage: ...
 
     @property
     @abstractmethod
-    def has_function_call(self) -> bool:
-        pass
+    def has_function_call(self) -> bool: ...
 
 
 class ChoiceConsumer(Consumer):
@@ -104,6 +99,9 @@ class ChoiceConsumer(Consumer):
         if exc is None and self._choice is not None:
             self._choice.close()
         return False
+
+    async def aflush(self):
+        await self.response.aflush()
 
     def is_empty(self) -> bool:
         return self.empty

--- a/aidial_adapter_vertexai/chat/gemini/adapter/genai_lib.py
+++ b/aidial_adapter_vertexai/chat/gemini/adapter/genai_lib.py
@@ -155,7 +155,9 @@ class GeminiGenAIChatCompletionAdapter(
         try:
             async for chunk in generator():
                 if log.isEnabledFor(DEBUG):
-                    chunk_str = json_dumps(chunk)
+                    chunk_str = json_dumps(
+                        chunk, exclude_none=True, exclude_empty_dict=True
+                    )
                     log.debug(f"response chunk: {chunk_str}")
 
                 if chunk.prompt_feedback:
@@ -197,9 +199,18 @@ class GeminiGenAIChatCompletionAdapter(
                     consumer.is_empty(),
                 ):
                     await consumer.set_finish_reason(openai_reason)
+
+                # NOTE: need to flush manually the SDK queue of chat completion chunks
+                # since google-genai<1.3.0 is based on synchronous `requests` HTTP client.
+                # Therefore, `requests` didn't release the async event loop on receiving chunks from the upstream.
+                # This led to the adapter responding with all generated chunks at once,
+                # which defeats the purpose of streaming.
+                # Could be removed once migrated to google-genai>=1.3.0
+                await consumer.aflush()
         finally:
             if thinking_stage:
                 thinking_stage.close()
+
             # It's possible that max tokens will be reached during the thinking stage
             # and there will be no content in response.
             # And set_usage will fail with 'Trying to set "usage" before generating all choices' error.

--- a/aidial_adapter_vertexai/utils/json.py
+++ b/aidial_adapter_vertexai/utils/json.py
@@ -51,7 +51,18 @@ def _to_dict(obj: Any, **kwargs) -> Any:
         return obj.value
 
     if isinstance(obj, dict):
-        return {key: rec(dict_field(key, value)) for key, value in obj.items()}
+        filters = []
+        if kwargs.get("exclude_none"):
+            filters.append(lambda x: x is not None)
+        if kwargs.get("exclude_empty_dict"):
+            filters.append(lambda x: x != {})
+
+        ret = {}
+        for k, v in obj.items():
+            v = rec(dict_field(k, v))
+            if all(f(v) for f in filters):
+                ret[k] = v
+        return ret
 
     if isinstance(obj, list):
         return [rec(element) for element in obj]


### PR DESCRIPTION
The streaming for models implemented via `google-genai` SDK _(that is all Gemini>=1.5 models)_ was compromised, since `google-genai<1.3.0` [used](https://github.com/googleapis/python-genai/commit/c38da8d4425a92bd6ba483abccc3dbeafbf8daa4) **synchronous** HTTP client `requests`, so that the chat completion chunks must be flushed manually, otherwise the adapter returns all chunks in one response.

Follow-up: once migrated from `google-genai==0.4.0` to `google-genai>=1.3.0`, the manual flushing could be removed.