### PR TITLE
feat: add Gemini 2.0 Flash Lite and Gemini 2.5 Flash models

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ The following models support `POST $SERVER_HOSTNAME/openai/deployments/$DEPLOYME
 
 |Model|Deployment name|Modality|`/tokenize`|`/truncate_prompt`|tools/functions support|
 |---|---|---|---|---|---|
+|Gemini 2.5 Flash|gemini-2.5-flash-preview-04-17|(text/pdf/image/audio/video)-to-text|✅|✅|✅|
 |Gemini 2.5 Pro|gemini-2.5-pro-exp-03-25/gemini-2.5-pro-preview-03-25|(text/pdf/image/audio/video)-to-text|✅|✅|✅|
 |Gemini 2.0 Pro|gemini-2.0-pro-exp-02-05|(text/pdf/image/audio/video)-to-text|✅|✅|✅|
+|Gemini 2.0 Flash Lite|gemini-2.0-flash-lite-001|(text/pdf/image/audio/video)-to-text|✅|✅|✅|
 |Gemini 2.0 Flash Thinking|gemini-2.0-flash-thinking-exp-01-21|text-to-text|✅|✅|❌|
 |Gemini 2.0 Flash|gemini-2.0-flash-(exp\|001)|(text/pdf/image/audio/video)-to-text|✅|✅|✅|
 |Gemini 2.0 Flash Lite|gemini-2.0-flash-lite-preview-02-05|(text/pdf/image/audio/video)-to-text|✅|✅|❌|

--- a/aidial_adapter_vertexai/adapters.py
+++ b/aidial_adapter_vertexai/adapters.py
@@ -83,6 +83,8 @@ async def get_chat_completion_model(
             | ChatCompletionDeployment.GEMINI_2_0_FLASH_LITE_PREVIEW_02_05
             | ChatCompletionDeployment.GEMINI_2_5_PRO_EXP_03_25
             | ChatCompletionDeployment.GEMINI_2_5_PRO_PREVIEW_03_25
+            | ChatCompletionDeployment.GEMINI_2_0_FLASH_LITE_1
+            | ChatCompletionDeployment.GEMINI_2_5_FLASH_PREVIEW_04_17
         ):
             return await GeminiGenAIChatCompletionAdapter.create(
                 storage,

--- a/aidial_adapter_vertexai/chat/gemini/adapter/genai_lib.py
+++ b/aidial_adapter_vertexai/chat/gemini/adapter/genai_lib.py
@@ -108,6 +108,8 @@ class GeminiGenAIChatCompletionAdapter(
                 | ChatCompletionDeployment.GEMINI_2_0_PRO_EXP_02_05
                 | ChatCompletionDeployment.GEMINI_2_5_PRO_EXP_03_25
                 | ChatCompletionDeployment.GEMINI_2_5_PRO_PREVIEW_03_25
+                | ChatCompletionDeployment.GEMINI_2_0_FLASH_LITE_1
+                | ChatCompletionDeployment.GEMINI_2_5_FLASH_PREVIEW_04_17
             ):
                 return await Gemini_2_Prompt.parse(
                     self.file_storage, tools, static_tools, messages

--- a/aidial_adapter_vertexai/chat/gemini/grounding.py
+++ b/aidial_adapter_vertexai/chat/gemini/grounding.py
@@ -47,6 +47,8 @@ def google_search_grounding_tokens(
             | ChatCompletionDeployment.GEMINI_2_0_FLASH_LITE_PREVIEW_02_05
             | ChatCompletionDeployment.GEMINI_2_5_PRO_EXP_03_25
             | ChatCompletionDeployment.GEMINI_2_5_PRO_PREVIEW_03_25
+            | ChatCompletionDeployment.GEMINI_2_0_FLASH_LITE_1
+            | ChatCompletionDeployment.GEMINI_2_5_FLASH_PREVIEW_04_17
         ):
             # TODO: Add pricing, when it will be available.
             # Currently, while this models are in experimental mode, there is no pricing information.

--- a/aidial_adapter_vertexai/deployments.py
+++ b/aidial_adapter_vertexai/deployments.py
@@ -14,18 +14,23 @@ class ChatCompletionDeployment(Enum):
     GEMINI_PRO = "gemini-pro"
     GEMINI_PRO_1 = "gemini-1.0-pro"
     GEMINI_PRO_VISION_1 = "gemini-pro-vision"
+
     GEMINI_PRO_1_5_PREVIEW = "gemini-1.5-pro-preview-0409"
     GEMINI_PRO_1_5_V1 = "gemini-1.5-pro-001"
     GEMINI_PRO_1_5_V2 = "gemini-1.5-pro-002"
     GEMINI_FLASH_1_5_V1 = "gemini-1.5-flash-001"
     GEMINI_FLASH_1_5_V2 = "gemini-1.5-flash-002"
+
+    GEMINI_2_0_FLASH_LITE_1 = "gemini-2.0-flash-lite-001"
     GEMINI_2_0_FLASH_THINKING_EXP_01_21 = "gemini-2.0-flash-thinking-exp-01-21"
     GEMINI_2_0_PRO_EXP_02_05 = "gemini-2.0-pro-exp-02-05"
     GEMINI_2_0_FLASH_EXP = "gemini-2.0-flash-exp"
     GEMINI_2_0_FLASH_001 = "gemini-2.0-flash-001"
     GEMINI_2_0_FLASH_LITE_PREVIEW_02_05 = "gemini-2.0-flash-lite-preview-02-05"
+
     GEMINI_2_5_PRO_EXP_03_25 = "gemini-2.5-pro-exp-03-25"
     GEMINI_2_5_PRO_PREVIEW_03_25 = "gemini-2.5-pro-preview-03-25"
+    GEMINI_2_5_FLASH_PREVIEW_04_17 = "gemini-2.5-flash-preview-04-17"
 
     IMAGEN_005 = "imagegeneration@005"
 
@@ -72,6 +77,8 @@ GeminiDeployment = Literal[
     ChatCompletionDeployment.GEMINI_2_0_FLASH_LITE_PREVIEW_02_05,
     ChatCompletionDeployment.GEMINI_2_5_PRO_EXP_03_25,
     ChatCompletionDeployment.GEMINI_2_5_PRO_PREVIEW_03_25,
+    ChatCompletionDeployment.GEMINI_2_0_FLASH_LITE_1,
+    ChatCompletionDeployment.GEMINI_2_5_FLASH_PREVIEW_04_17,
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ google-auth-oauthlib = "1.0.0"
 # -n=auto --self-contained-html --html=pytest.html --alluredir=allure-results --timeout=60
 
 [tool.pytest.ini_options]
-addopts = "--asyncio-mode=auto"
+addopts = "-n=auto --asyncio-mode=auto --self-contained-html --html=pytest.html --alluredir=allure-results --timeout=60"
 env_override_existing_values = 1
 filterwarnings = [
     "error",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,6 @@ pyright = "1.1.389"
 nox = "^2023.4.22"
 google-auth-oauthlib = "1.0.0"
 
-# -n=auto --self-contained-html --html=pytest.html --alluredir=allure-results --timeout=60
-
 [tool.pytest.ini_options]
 addopts = "-n=auto --asyncio-mode=auto --self-contained-html --html=pytest.html --alluredir=allure-results --timeout=60"
 env_override_existing_values = 1

--- a/tests/integration_tests/test_chat_completion_generation.py
+++ b/tests/integration_tests/test_chat_completion_generation.py
@@ -97,6 +97,8 @@ chat_deployments: Mapping[ChatCompletionDeployment, str] = {
     ChatCompletionDeployment.GEMINI_2_0_FLASH_LITE_PREVIEW_02_05: _CENTRAL,
     ChatCompletionDeployment.GEMINI_2_5_PRO_EXP_03_25: _CENTRAL,
     ChatCompletionDeployment.GEMINI_2_0_FLASH_THINKING_EXP_01_21: _CENTRAL,
+    ChatCompletionDeployment.GEMINI_2_0_FLASH_LITE_1: _CENTRAL,
+    ChatCompletionDeployment.GEMINI_2_5_FLASH_PREVIEW_04_17: _CENTRAL,
     ChatCompletionDeployment.CLAUDE_3_5_SONNET_V2: _EAST,
     ChatCompletionDeployment.CLAUDE_3_5_HAIKU: _EAST,
     ChatCompletionDeployment.CLAUDE_3_OPUS: _EAST,
@@ -149,14 +151,7 @@ def supports_json_schema_response_format(
 
 
 def is_claude(deployment: ChatCompletionDeployment) -> bool:
-    return deployment in [
-        ChatCompletionDeployment.CLAUDE_3_5_SONNET_V2,
-        ChatCompletionDeployment.CLAUDE_3_5_HAIKU,
-        ChatCompletionDeployment.CLAUDE_3_OPUS,
-        ChatCompletionDeployment.CLAUDE_3_5_SONNET,
-        ChatCompletionDeployment.CLAUDE_3_HAIKU,
-        ChatCompletionDeployment.CLAUDE_3_7_SONNET,
-    ]
+    return "claude" in deployment.value
 
 
 def supports_tools(deployment: ChatCompletionDeployment) -> bool:
@@ -167,6 +162,8 @@ def supports_tools(deployment: ChatCompletionDeployment) -> bool:
         ChatCompletionDeployment.GEMINI_2_0_FLASH_001,
         ChatCompletionDeployment.GEMINI_2_0_PRO_EXP_02_05,
         ChatCompletionDeployment.GEMINI_2_5_PRO_EXP_03_25,
+        ChatCompletionDeployment.GEMINI_2_0_FLASH_LITE_1,
+        ChatCompletionDeployment.GEMINI_2_5_FLASH_PREVIEW_04_17,
     ]
 
 
@@ -179,6 +176,8 @@ def supports_parallel_tool_calls(deployment: ChatCompletionDeployment) -> bool:
         ChatCompletionDeployment.CLAUDE_3_5_SONNET,
         # ChatCompletionDeployment.CLAUDE_3_7_SONNET,
         ChatCompletionDeployment.GEMINI_2_5_PRO_EXP_03_25,
+        ChatCompletionDeployment.GEMINI_2_0_FLASH_LITE_1,
+        ChatCompletionDeployment.GEMINI_2_5_FLASH_PREVIEW_04_17,
     ]
 
 
@@ -187,16 +186,10 @@ def supports_tool_call_ids(deployment: ChatCompletionDeployment) -> bool:
 
 
 def supports_grounding(deployment: ChatCompletionDeployment) -> bool:
-    return deployment in [
-        ChatCompletionDeployment.GEMINI_PRO_1,
-        ChatCompletionDeployment.GEMINI_PRO_1_5_V1,
-        ChatCompletionDeployment.GEMINI_PRO_1_5_V2,
-        ChatCompletionDeployment.GEMINI_FLASH_1_5_V1,
-        ChatCompletionDeployment.GEMINI_FLASH_1_5_V2,
-        ChatCompletionDeployment.GEMINI_2_0_FLASH_EXP,
-        ChatCompletionDeployment.GEMINI_2_0_FLASH_001,
-        ChatCompletionDeployment.GEMINI_2_5_PRO_EXP_03_25,
-    ]
+    return (
+        "gemini" in deployment.value
+        and deployment != ChatCompletionDeployment.GEMINI_PRO_VISION_1
+    )
 
 
 def supports_text_input(deployment: ChatCompletionDeployment) -> bool:
@@ -244,18 +237,12 @@ def support_thinking(deployment: ChatCompletionDeployment) -> bool:
         # Gemini 2.5 doesn't emit thinking tokens into a separate output,
         # it's all the part of the completion tokens.
         ChatCompletionDeployment.GEMINI_2_5_PRO_EXP_03_25,
+        ChatCompletionDeployment.GEMINI_2_5_FLASH_PREVIEW_04_17,
     ]
 
 
 def is_gemini_2(deployment: ChatCompletionDeployment) -> bool:
-    return deployment in [
-        ChatCompletionDeployment.GEMINI_2_0_FLASH_EXP,
-        ChatCompletionDeployment.GEMINI_2_0_FLASH_001,
-        ChatCompletionDeployment.GEMINI_2_0_FLASH_THINKING_EXP_01_21,
-        ChatCompletionDeployment.GEMINI_2_0_FLASH_LITE_PREVIEW_02_05,
-        ChatCompletionDeployment.GEMINI_2_0_PRO_EXP_02_05,
-        ChatCompletionDeployment.GEMINI_2_5_PRO_EXP_03_25,
-    ]
+    return "gemini-2." in deployment.value
 
 
 def get_test_cases(

--- a/tests/unit_tests/test_endpoints.py
+++ b/tests/unit_tests/test_endpoints.py
@@ -42,6 +42,8 @@ test_cases: List[TestCase] = [
     TestCase(D.GEMINI_2_0_PRO_EXP_02_05, True, True),
     TestCase(D.GEMINI_2_5_PRO_EXP_03_25, True, True),
     TestCase(D.GEMINI_2_5_PRO_PREVIEW_03_25, True, True),
+    TestCase(D.GEMINI_2_0_FLASH_LITE_1, True, True),
+    TestCase(D.GEMINI_2_5_FLASH_PREVIEW_04_17, True, True),
     TestCase(D.CLAUDE_3_5_SONNET_V2, True, True),
     TestCase(D.CLAUDE_3_5_HAIKU, True, True),
     TestCase(D.CLAUDE_3_OPUS, True, True),


### PR DESCRIPTION
Resolves https://github.com/epam/ai-dial-adapter-vertexai/issues/226

It's functionally equivalent to using the following mapping:

```
COMPATIBILITY_MAPPING={"gemini-2.0-flash-lite-001":"gemini-2.0-flash-001","gemini-2.5-flash-preview-04-17":"gemini-2.0-flash-001"}
```