### PR TITLE
fix: increase default `max_tokens` for Claude models up to 1536

### DIFF
--- a/aidial_adapter_vertexai/chat/claude/params.py
+++ b/aidial_adapter_vertexai/chat/claude/params.py
@@ -7,7 +7,7 @@ from anthropic.types.message_create_params import ToolChoice
 from aidial_adapter_vertexai.chat.claude.prompt.base import ClaudePrompt
 from aidial_adapter_vertexai.dial_api.request import ModelParameters
 
-_DEFAULT_MAX_TOKENS_CLAUDE = 512
+_DEFAULT_MAX_TOKENS_CLAUDE = 1536
 
 
 _T = TypeVar("_T")


### PR DESCRIPTION
To keep it in line with the default for [Bedrock Claude models](https://github.com/epam/ai-dial-adapter-bedrock/blob/f6054d165c4f111cec32f03682fd75e716fe6c32/aidial_adapter_bedrock/llm/model/conf.py#L5).