### PR TITLE
feat: add env var for Claude's default `max_tokens` value

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Copy `.env.example` to `.env` and customize it for your environment:
 |WEB_CONCURRENCY|1|Number of workers for the server|
 |DIAL_URL||URL of the core DIAL server. Optional. Used to access images stored in the DIAL File storage|
 |COMPATIBILITY_MAPPING|{}|A JSON dictionary that maps VertexAI deployments that **aren't supported** by the Adapter to the VertexAI deployments that **are supported** by the Adapter _(see the [Supported models](#supported-models)_ section). Find more details in the [compatibility mode](#compatibility-mode) section.|
-|CLAUDE_DEFAULT_MAX_TOKENS|1536|The default value of `max_tokens` chat completion parameter if it is not provided in the request. Unlike OpenAI models, Claude models require the `max_tokens` parameter. <code style="color:red">⚠ Using the variable is discouraged</code>. Consider configuring the default in the DIAL Core Config instead as demonstrated in the [example below](#default-max_tokens-for-claude-models).|
+|CLAUDE_DEFAULT_MAX_TOKENS|1536|The default value of `max_tokens` chat completion parameter if it is not provided in the request. Unlike OpenAI models, Claude models require the `max_tokens` parameter. **:warning: ⚠️ Using the variable is discouraged**. Consider configuring the default in the DIAL Core Config instead as demonstrated in the [example below](#default-max_tokens-for-claude-models).|
 
 ## Default `max_tokens` for Claude models
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,12 @@ Copy `.env.example` to `.env` and customize it for your environment:
 |WEB_CONCURRENCY|1|Number of workers for the server|
 |DIAL_URL||URL of the core DIAL server. Optional. Used to access images stored in the DIAL File storage|
 |COMPATIBILITY_MAPPING|{}|A JSON dictionary that maps VertexAI deployments that **aren't supported** by the Adapter to the VertexAI deployments that **are supported** by the Adapter _(see the [Supported models](#supported-models)_ section). Find more details in the [compatibility mode](#compatibility-mode) section.|
-|CLAUDE_DEFAULT_MAX_TOKENS|1536|The default value of `max_tokens` chat completion parameter if it is not provided in the request. Unlike OpenAI models, Claude models require the `max_tokens` parameter. **:warning: ⚠️ Using the variable is discouraged**. Consider configuring the default in the DIAL Core Config instead as demonstrated in the [example below](#default-max_tokens-for-claude-models).|
+|CLAUDE_DEFAULT_MAX_TOKENS|1536|The default value of `max_tokens` chat completion parameter if it is not provided in the request.**:warning: Using the variable is discouraged**. Consider configuring the default in the DIAL Core Config instead as demonstrated in the [example below](#default-max_tokens-for-claude-models).|
 
 ## Default `max_tokens` for Claude models
 
-Unlike OpenAI models, Claude models require the `max_tokens` parameter in the chat completion request.
+Unlike Gemini models, Claude models require the `max_tokens` parameter in the chat completion request.
+
 We recommend configuring `max_tokens` default value on a per-model basis in the DIAL Core Config, for example:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Copy `.env.example` to `.env` and customize it for your environment:
 |WEB_CONCURRENCY|1|Number of workers for the server|
 |DIAL_URL||URL of the core DIAL server. Optional. Used to access images stored in the DIAL File storage|
 |COMPATIBILITY_MAPPING|{}|A JSON dictionary that maps VertexAI deployments that **aren't supported** by the Adapter to the VertexAI deployments that **are supported** by the Adapter _(see the [Supported models](#supported-models)_ section). Find more details in the [compatibility mode](#compatibility-mode) section.|
-|CLAUDE_DEFAULT_MAX_TOKENS|1536|The default value of `max_tokens` chat completion parameter if it is not provided in the request.**:warning: Using the variable is discouraged**. Consider configuring the default in the DIAL Core Config instead as demonstrated in the [example below](#default-max_tokens-for-claude-models).|
+|CLAUDE_DEFAULT_MAX_TOKENS|1536|The default value of `max_tokens` chat completion parameter if it is not provided in the request.<br>**:warning: Using the variable is discouraged**. Consider configuring the default in the DIAL Core Config instead as demonstrated in the [example below](#default-max_tokens-for-claude-models).|
 
 ## Default `max_tokens` for Claude models
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Copy `.env.example` to `.env` and customize it for your environment:
 |WEB_CONCURRENCY|1|Number of workers for the server|
 |DIAL_URL||URL of the core DIAL server. Optional. Used to access images stored in the DIAL File storage|
 |COMPATIBILITY_MAPPING|{}|A JSON dictionary that maps VertexAI deployments that **aren't supported** by the Adapter to the VertexAI deployments that **are supported** by the Adapter _(see the [Supported models](#supported-models)_ section). Find more details in the [compatibility mode](#compatibility-mode) section.|
-|CLAUDE_DEFAULT_MAX_TOKENS|1536|The default value of `max_tokens` chat completion parameter if it is not provided in the request.<br>**:warning: Using the variable is discouraged**. Consider configuring the default in the DIAL Core Config instead as demonstrated in the [example below](#default-max_tokens-for-claude-models).|
+|CLAUDE_DEFAULT_MAX_TOKENS|1536|The default value of `max_tokens` chat completion parameter if it is not provided in the request.<br>**:warning: Using the variable is discouraged**.<br>Consider configuring the default in the DIAL Core Config instead as demonstrated in the [example below](#default-max_tokens-for-claude-models).|
 
 ## Default `max_tokens` for Claude models
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Copy `.env.example` to `.env` and customize it for your environment:
 > ```
 >
 > Such a **per-model** configuration is cleaner since all the information relevant to tokens _(like pricing and token limits)_ is kept in the same place.
+>
+> The default value set in the DIAL Core Config takes precedence over the one configured in the adapter.
 
 ## Compatibility mode
 

--- a/README.md
+++ b/README.md
@@ -67,29 +67,35 @@ Copy `.env.example` to `.env` and customize it for your environment:
 |WEB_CONCURRENCY|1|Number of workers for the server|
 |DIAL_URL||URL of the core DIAL server. Optional. Used to access images stored in the DIAL File storage|
 |COMPATIBILITY_MAPPING|{}|A JSON dictionary that maps VertexAI deployments that **aren't supported** by the Adapter to the VertexAI deployments that **are supported** by the Adapter _(see the [Supported models](#supported-models)_ section). Find more details in the [compatibility mode](#compatibility-mode) section.|
-|CLAUDE_DEFAULT_MAX_TOKENS|1536|The default value of `max_tokens` chat completion parameter if it is not provided in the request. Claude models require the `max_tokens` parameter unlike OpenAI models. Make sure this value doesn't exceed Claude's [max output tokens](https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table), otherwise, you will receive an error like this one: `max_tokens: 10000 > 8192, which is the maximum allowed number of output tokens for claude-deployment-id`.|
+|CLAUDE_DEFAULT_MAX_TOKENS|1536|The default value of `max_tokens` chat completion parameter if it is not provided in the request. Unlike OpenAI models, Claude models require the `max_tokens` parameter. <code style="color:red">⚠ Using the variable is discouraged</code>. Consider configuring the default in the DIAL Core Config instead as demonstrated in the [example below](#default-max_tokens-for-claude-models).|
 
-> [!WARNING]
-> Using the `CLAUDE_DEFAULT_MAX_TOKENS` variable is **discouraged**. We recommend configuring `max_tokens` default value on a per-model basis in the DIAL Core Config instead, for example:
->
-> ```json
-> {
->     "models": {
->         "dial-claude-deployment-id": {
->             "type": "chat",
->             "description": "...",
->             "endpoint": "...",
->             "defaults": {
->                 "max_tokens": 2048
->             }
->         }
->     }
-> }
-> ```
->
-> Such a **per-model** configuration is cleaner since all the information relevant to tokens _(like pricing and token limits)_ is kept in the same place.
->
-> The default value set in the DIAL Core Config takes precedence over the one configured in the adapter.
+## Default `max_tokens` for Claude models
+
+Unlike OpenAI models, Claude models require the `max_tokens` parameter in the chat completion request.
+We recommend configuring `max_tokens` default value on a per-model basis in the DIAL Core Config, for example:
+
+```json
+{
+    "models": {
+        "dial-claude-deployment-id": {
+            "type": "chat",
+            "description": "...",
+            "endpoint": "...",
+            "defaults": {
+                "max_tokens": 2048
+            }
+        }
+    }
+}
+```
+
+If the default is missing in the DIAL Core Config, it will be taken from the `CLAUDE_DEFAULT_MAX_TOKENS` environment variable.
+However, we strongly recommend not to rely on this variable and instead configure the defaults in the DIAL Core Config.
+Such a **per-model** configuration is operationally cleaner since all the information relevant to tokens _(like pricing and token limits)_ is kept in the same place.
+
+The default value set in the DIAL Core Config takes precedence over the one configured in the adapter.
+
+Make sure the default doesn't exceed Claude's [max output tokens](https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table), otherwise, you will receive an error like this one: `max_tokens: 10000 > 8192, which is the maximum allowed number of output tokens for claude-3...)`.
 
 ## Compatibility mode
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,27 @@ Copy `.env.example` to `.env` and customize it for your environment:
 |WEB_CONCURRENCY|1|Number of workers for the server|
 |DIAL_URL||URL of the core DIAL server. Optional. Used to access images stored in the DIAL File storage|
 |COMPATIBILITY_MAPPING|{}|A JSON dictionary that maps VertexAI deployments that **aren't supported** by the Adapter to the VertexAI deployments that **are supported** by the Adapter _(see the [Supported models](#supported-models)_ section). Find more details in the [compatibility mode](#compatibility-mode) section.|
+|CLAUDE_DEFAULT_MAX_TOKENS|1536|The default value of `max_tokens` chat completion parameter if it is not provided in the request. Claude models require the `max_tokens` parameter unlike OpenAI models. Make sure this value doesn't exceed Claude's [max output tokens](https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table), otherwise, you will receive an error like this one: `max_tokens: 10000 > 8192, which is the maximum allowed number of output tokens for claude-deployment-id`.|
+
+> [!WARNING]
+> Using the `CLAUDE_DEFAULT_MAX_TOKENS` variable is **discouraged**. We recommend configuring `max_tokens` default value on a per-model basis in the DIAL Core Config instead, for example:
+>
+> ```json
+> {
+>     "models": {
+>         "dial-claude-deployment-id": {
+>             "type": "chat",
+>             "description": "...",
+>             "endpoint": "...",
+>             "defaults": {
+>                 "max_tokens": 2048
+>             }
+>         }
+>     }
+> }
+> ```
+>
+> Such a **per-model** configuration is cleaner since all the information relevant to tokens _(like pricing and token limits)_ is kept in the same place.
 
 ## Compatibility mode
 

--- a/aidial_adapter_vertexai/chat/claude/params.py
+++ b/aidial_adapter_vertexai/chat/claude/params.py
@@ -6,8 +6,9 @@ from anthropic.types.message_create_params import ToolChoice
 
 from aidial_adapter_vertexai.chat.claude.prompt.base import ClaudePrompt
 from aidial_adapter_vertexai.dial_api.request import ModelParameters
+from aidial_adapter_vertexai.utils.env import get_env_int
 
-_DEFAULT_MAX_TOKENS_CLAUDE = 1536
+_DEFAULT_MAX_TOKENS = get_env_int("CLAUDE_DEFAULT_MAX_TOKENS", 1536)
 
 
 _T = TypeVar("_T")
@@ -37,7 +38,7 @@ def create_chat_params(
 
     temperature = none_to_not_given(params.temperature)
     stop_sequences = none_to_not_given(params.stop)
-    max_tokens = params.max_tokens or _DEFAULT_MAX_TOKENS_CLAUDE
+    max_tokens = params.max_tokens or _DEFAULT_MAX_TOKENS
     top_p = none_to_not_given(params.top_p)
 
     return {

--- a/aidial_adapter_vertexai/utils/env.py
+++ b/aidial_adapter_vertexai/utils/env.py
@@ -12,6 +12,10 @@ def get_env(name: str) -> str:
     raise Exception(f"{name} env variable is not set")
 
 
+def get_env_int(name: str, default: int) -> int:
+    return int(os.getenv(name) or default)
+
+
 def get_str_dict(name: str) -> Dict[str, str]:
     if (val := os.getenv(name)) is None:
         return {}


### PR DESCRIPTION
The env var called `CLAUDE_DEFAULT_MAX_TOKENS`.
Its usage is highly **discouraged** though.
It was added solely to ease troubleshooting when clients run into issues related to `max_tokens`.