### PR TITLE
fix: Imagen: remove invalid `safety_filter_level` parameter

### DIFF
--- a/aidial_adapter_vertexai/chat/imagen/configuration.py
+++ b/aidial_adapter_vertexai/chat/imagen/configuration.py
@@ -1,8 +1,4 @@
-from google.genai.types import (
-    GenerateImagesConfigDict,
-    PersonGeneration,
-    SafetyFilterLevel,
-)
+from google.genai.types import GenerateImagesConfigDict, PersonGeneration
 from pydantic.v1 import Field
 
 from aidial_adapter_vertexai.utils.pydantic import ExtraAllowModel
@@ -53,7 +49,6 @@ class ImagenConfig(ExtraAllowModel):
     def to_config_dict(self, seed: int | None) -> GenerateImagesConfigDict:
         ret: GenerateImagesConfigDict = {
             "seed": seed,
-            "safety_filter_level": SafetyFilterLevel.BLOCK_NONE,
             "negative_prompt": self.negative_prompt,
             "add_watermark": self.add_watermark,
             "aspect_ratio": self.aspect_ratio,


### PR DESCRIPTION
Fixing the regression introduced by https://github.com/epam/ai-dial-adapter-vertexai/pull/262

The bug leads to the 400 error from any image generation request:

> google.genai.errors.ClientError: 400 FAILED_PRECONDITION. {'error': {'code': 400, 'message': 'Image generation failed with the following error: Invalid rai level from the request', 'status': 'FAILED_PRECONDITION'}}

The safety settings [aren't supported](https://cloud.google.com/vertex-ai/generative-ai/docs/image/migrate-to-imagen-3#which-model) for the Imagen 005 model:

<img width="904" alt="Screenshot 2025-07-04 at 10 34 15" src="https://github.com/user-attachments/assets/31429afa-33c0-421f-b4b0-43c0720b9d31" />
