### PR TITLE
feat: Gemini: support `tool_choice` parameter

### DIFF
--- a/aidial_adapter_vertexai/chat/gemini/generation_config.py
+++ b/aidial_adapter_vertexai/chat/gemini/generation_config.py
@@ -62,9 +62,12 @@ def create_genai_generation_config(
     if supports_image_generation:
         response_modalities = ["TEXT", "IMAGE"]
 
+    tool_config = tools.to_gemini_genai_tool_config()
+
     return GenAIGenerationConfig(
         system_instruction=config.get("system_instruction"),
         tools=config.get("tools"),  # type: ignore
+        tool_config=tool_config,
         max_output_tokens=params.max_tokens,
         temperature=params.temperature,
         stop_sequences=params.stop,

--- a/aidial_adapter_vertexai/chat/tools.py
+++ b/aidial_adapter_vertexai/chat/tools.py
@@ -259,20 +259,16 @@ class ToolsConfig(BaseModel):
             return None
 
         if self.required:
-            return GenAIToolConfig(
-                function_calling_config=GenAIFunctionCallingConfig(
-                    mode=GenAIFunctionCallingConfigMode.ANY,
-                    allowed_function_names=[
-                        func.name for func in self.functions
-                    ],
-                )
+            config = GenAIFunctionCallingConfig(
+                mode=GenAIFunctionCallingConfigMode.ANY,
+                allowed_function_names=[func.name for func in self.functions],
             )
         else:
-            return GenAIToolConfig(
-                function_calling_config=GenAIFunctionCallingConfig(
-                    mode=GenAIFunctionCallingConfigMode.AUTO,
-                )
+            config = GenAIFunctionCallingConfig(
+                mode=GenAIFunctionCallingConfigMode.AUTO
             )
+
+        return GenAIToolConfig(function_calling_config=config)
 
 
 def validate_messages(request: AzureChatCompletionRequest) -> None:

--- a/tests/integration_tests/test_chat_completion_generation.py
+++ b/tests/integration_tests/test_chat_completion_generation.py
@@ -1,5 +1,5 @@
 import json
-from typing import Awaitable, Callable, List, Mapping, Unpack
+from typing import Awaitable, Callable, List, Mapping, Protocol, Unpack
 
 import openai
 import pytest
@@ -194,7 +194,10 @@ def create_message_with_image(request) -> Callable:
     return request.param
 
 
-Chat = Callable[..., Awaitable[ChatCompletionResult]]
+class Chat(Protocol):
+    def __call__(
+        self, **kwargs: Unpack[ChatCompletionArgs]
+    ) -> Awaitable[ChatCompletionResult]: ...
 
 
 @pytest.fixture
@@ -599,6 +602,30 @@ async def test_tool_call_zero_parameters(chat: Chat):
 
     tool_calls = response.tool_calls
     assert tool_calls is not None, "Tool calls are missing"
+    assert tool_calls[0].function.name == "get_current_time"
+
+
+@pytest.mark.parametrize(
+    "deployment",
+    select(pred(supports_tools), deployments),
+    ids=display_deployment,
+)
+async def test_tool_call_required(chat: Chat):
+    response = await chat(
+        messages=[user("How are you?")],
+        tools=[
+            function_to_tool(
+                {
+                    "name": "get_current_time",
+                    "description": "return the current time",
+                }
+            )
+        ],
+        tool_choice="required",
+    )
+
+    tool_calls = response.tool_calls
+    assert tool_calls is not None, "Tool call is missing"
     assert tool_calls[0].function.name == "get_current_time"
 
 

--- a/tests/integration_tests/test_tokenization.py
+++ b/tests/integration_tests/test_tokenization.py
@@ -8,7 +8,7 @@ from openai.types.chat import (
     ChatCompletionMessageParam,
     ChatCompletionToolParam,
 )
-from openai.types.chat.completion_create_params import Function
+from openai.types.shared_params.function_definition import FunctionDefinition
 
 from aidial_adapter_vertexai.deployments import ChatCompletionDeployment
 from tests.conftest import get_extra_headers
@@ -49,7 +49,7 @@ class TestCase:
     messages: List[ChatCompletionMessageParam]
     expected_error: str | None
 
-    functions: List[Function] | None
+    functions: List[FunctionDefinition] | None
     tools: List[ChatCompletionToolParam] | None
 
     def get_id(self):
@@ -93,7 +93,7 @@ def get_test_cases(
         name: str,
         messages: List[ChatCompletionMessageParam],
         error: str | None = None,
-        functions: List[Function] | None = None,
+        functions: List[FunctionDefinition] | None = None,
         tools: List[ChatCompletionToolParam] | None = None,
     ) -> None:
         test_cases.append(

--- a/tests/utils/openai.py
+++ b/tests/utils/openai.py
@@ -21,6 +21,7 @@ from openai.types.chat import (
     ChatCompletionMessageToolCall,
     ChatCompletionMessageToolCallParam,
     ChatCompletionSystemMessageParam,
+    ChatCompletionToolChoiceOptionParam,
     ChatCompletionToolMessageParam,
     ChatCompletionToolParam,
     ChatCompletionUserMessageParam,
@@ -32,7 +33,6 @@ from openai.types.chat.chat_completion_message import (
 from openai.types.chat.chat_completion_message_tool_call_param import (
     Function as ToolFunction,
 )
-from openai.types.chat.completion_create_params import Function
 from openai.types.shared_params.function_definition import FunctionDefinition
 from pydantic.v1 import BaseModel
 
@@ -221,7 +221,7 @@ async def tokenize_request(
     http_client: httpx.AsyncClient,
     model_id: str,
     messages: List[ChatCompletionMessageParam],
-    functions: List[Function] | None,
+    functions: List[FunctionDefinition] | None,
     tools: List[ChatCompletionToolParam] | None,
     extra_headers: Mapping[str, str] | None = None,
 ) -> TokenizeResponse:
@@ -270,8 +270,9 @@ class ChatCompletionArgs(TypedDict, total=False):
     stop: List[str] | None
     max_tokens: int | None
     n: int | None
-    functions: List[Function] | None
+    functions: List[FunctionDefinition] | None
     tools: List[ChatCompletionToolParam] | None
+    tool_choice: ChatCompletionToolChoiceOptionParam | None
     static_tools: StaticToolsConfig | None
     configuration: dict | None
     extra_body: dict | None
@@ -318,9 +319,9 @@ async def chat_completion(
             max_tokens=kwargs.get("max_tokens"),
             temperature=0.0,
             n=kwargs.get("n"),
-            function_call="auto" if functions is not None else NOT_GIVEN,
+            function_call=NOT_GIVEN,
             functions=functions or NOT_GIVEN,
-            tool_choice="auto" if tools is not None else NOT_GIVEN,
+            tool_choice=kwargs.get("tool_choice") or NOT_GIVEN,
             tools=tools or NOT_GIVEN,
             extra_body=extra_body,
         )


### PR DESCRIPTION
`to_gemini_genai_tool_config` method was introduced in https://github.com/epam/ai-dial-adapter-vertexai/pull/172, but by an oversight, wasn't used anywhere, meaning that `tool_choice` parameter didn't reach the upstream.