### PR TITLE
fix: Gemini 2.5 Flash Image: fix false positive content filter finish reason

### DIFF
--- a/aidial_adapter_vertexai/chat/gemini/adapter/genai_lib.py
+++ b/aidial_adapter_vertexai/chat/gemini/adapter/genai_lib.py
@@ -228,7 +228,9 @@ class GeminiGenAIChatCompletionAdapter(
                     chunk_str = json_dumps(chunk, exclude_none=True)
                     log.debug(f"response chunk: {chunk_str}")
 
-                if chunk.prompt_feedback:
+                if (feedback := chunk.prompt_feedback) and (
+                    feedback.block_reason or feedback.block_reason_message
+                ):
                     await consumer.set_finish_reason(
                         FinishReason.CONTENT_FILTER
                     )


### PR DESCRIPTION
Despite Google GenAI library [documentation](https://github.com/googleapis/python-genai/blob/v1.38.0/google/genai/types.py#L5472-L5475), this field could be present and equal to an empty dictionary even when **content wasn't filtered**:

```python
  prompt_feedback: Optional[GenerateContentResponsePromptFeedback] = Field(
      default=None,
      description="""Output only. Content filter results for a prompt sent in the request. Note: Sent only in the first stream chunk. Only happens when no candidates were generated due to content violations.""",
  )
```

Fixed by inspecting the content of the `prompt_feedback` field instead of relying on its presence or absence.