### PR TITLE
fix: fix unclosed session/socket warnings

### DIFF
--- a/aidial_adapter_vertexai/app.py
+++ b/aidial_adapter_vertexai/app.py
@@ -4,7 +4,11 @@ from aidial_sdk import DIALApp
 from aidial_sdk.telemetry.types import TelemetryConfig
 
 from aidial_adapter_vertexai.adapter_deployments import AdapterDeployments
-from aidial_adapter_vertexai.app_config import init_vertex_ai
+from aidial_adapter_vertexai.app_config import (
+    get_anthropic_client,
+    get_genai_client,
+    init_vertex_ai,
+)
 from aidial_adapter_vertexai.chat_completion import VertexAIChatCompletion
 from aidial_adapter_vertexai.dial_api.exceptions import dial_exception_decorator
 from aidial_adapter_vertexai.dial_api.response import (
@@ -20,6 +24,8 @@ from aidial_adapter_vertexai.utils.log_config import configure_loggers
 async def lifespan(app: DIALApp):
     init_vertex_ai()
     yield
+    await get_genai_client.clear()
+    await get_anthropic_client.clear()
 
 
 app = DIALApp(

--- a/aidial_adapter_vertexai/app.py
+++ b/aidial_adapter_vertexai/app.py
@@ -18,6 +18,10 @@ from aidial_adapter_vertexai.dial_api.response import (
 from aidial_adapter_vertexai.embeddings import VertexAIEmbeddings
 from aidial_adapter_vertexai.utils.env import get_str_dict
 from aidial_adapter_vertexai.utils.log_config import configure_loggers
+from aidial_adapter_vertexai.vertex_ai import (
+    get_multi_modal_embedding_model,
+    get_text_embedding_model,
+)
 
 
 @asynccontextmanager
@@ -26,6 +30,8 @@ async def lifespan(app: DIALApp):
     yield
     await get_genai_client.clear()
     await get_anthropic_client.clear()
+    await get_text_embedding_model.clear()
+    await get_multi_modal_embedding_model.clear()
 
 
 app = DIALApp(

--- a/aidial_adapter_vertexai/app_config.py
+++ b/aidial_adapter_vertexai/app_config.py
@@ -1,10 +1,10 @@
 import os
-from functools import cache
 
 import vertexai
 from anthropic import AsyncAnthropicVertex
 from google.genai.client import Client as GenAIClient
 
+from aidial_adapter_vertexai.utils.cache import cache as cache_with_close
 from aidial_adapter_vertexai.utils.log_config import app_logger as log
 
 DEFAULT_REGION_ENV_VAR = "DEFAULT_REGION"
@@ -23,11 +23,22 @@ def init_vertex_ai():
         )
 
 
-@cache
-def get_genai_client(project: str, location: str) -> GenAIClient:
+async def _close_genai_client(client: GenAIClient) -> None:
+    if session := client._api_client._aiohttp_session:
+        await session.close()
+
+
+@cache_with_close(close=_close_genai_client)
+async def get_genai_client(project: str, location: str) -> GenAIClient:
     return GenAIClient(vertexai=True, project=project, location=location)
 
 
-@cache
-def get_anthropic_client(project: str, region: str) -> AsyncAnthropicVertex:
+async def _close_anthropic_client(client: AsyncAnthropicVertex) -> None:
+    await client.close()
+
+
+@cache_with_close(close=_close_anthropic_client)
+async def get_anthropic_client(
+    project: str, region: str
+) -> AsyncAnthropicVertex:
     return AsyncAnthropicVertex(project_id=project, region=region)

--- a/aidial_adapter_vertexai/app_config.py
+++ b/aidial_adapter_vertexai/app_config.py
@@ -4,7 +4,7 @@ import vertexai
 from anthropic import AsyncAnthropicVertex
 from google.genai.client import Client as GenAIClient
 
-from aidial_adapter_vertexai.utils.cache import cache as cache_with_close
+from aidial_adapter_vertexai.utils.cache import cache
 from aidial_adapter_vertexai.utils.log_config import app_logger as log
 
 DEFAULT_REGION_ENV_VAR = "DEFAULT_REGION"
@@ -28,7 +28,7 @@ async def _close_genai_client(client: GenAIClient) -> None:
         await session.close()
 
 
-@cache_with_close(close=_close_genai_client)
+@cache(_close_genai_client)
 async def get_genai_client(project: str, location: str) -> GenAIClient:
     return GenAIClient(vertexai=True, project=project, location=location)
 
@@ -37,7 +37,7 @@ async def _close_anthropic_client(client: AsyncAnthropicVertex) -> None:
     await client.close()
 
 
-@cache_with_close(close=_close_anthropic_client)
+@cache(_close_anthropic_client)
 async def get_anthropic_client(
     project: str, region: str
 ) -> AsyncAnthropicVertex:

--- a/aidial_adapter_vertexai/chat/claude/adapter.py
+++ b/aidial_adapter_vertexai/chat/claude/adapter.py
@@ -134,7 +134,8 @@ class ClaudeChatCompletionAdapter(ChatCompletionAdapter[ClaudePrompt]):
         deployment: AdapterDeployment[ClaudeDeployment],
         config: UpstreamConfig,
     ) -> "ClaudeChatCompletionAdapter":
-        return cls(file_storage, deployment, config.get_anthropic_client())
+        client = await config.get_anthropic_client()
+        return cls(file_storage, deployment, client)
 
     @override
     async def configuration(self) -> Type[ClaudeConfiguration]:

--- a/aidial_adapter_vertexai/chat/gemini/adapter/genai_lib.py
+++ b/aidial_adapter_vertexai/chat/gemini/adapter/genai_lib.py
@@ -120,7 +120,8 @@ class GeminiGenAIChatCompletionAdapter(
         deployment: AdapterDeployment[GeminiDeployment],
         config: UpstreamConfig,
     ) -> "GeminiGenAIChatCompletionAdapter":
-        return cls(file_storage, deployment, config.get_genai_client())
+        client = await config.get_genai_client()
+        return cls(file_storage, deployment, client)
 
     @property
     def model_id(self) -> str:

--- a/aidial_adapter_vertexai/chat/imagen/adapter.py
+++ b/aidial_adapter_vertexai/chat/imagen/adapter.py
@@ -163,7 +163,8 @@ class ImagenChatCompletionAdapter(ChatCompletionAdapter[ImagenPrompt]):
         deployment: AdapterDeployment[ImagenDeployment],
         config: UpstreamConfig,
     ) -> "ImagenChatCompletionAdapter":
-        return cls(file_storage, config.get_genai_client(), deployment)
+        client = await config.get_genai_client()
+        return cls(file_storage, client, deployment)
 
 
 def _prepare_generation_config(

--- a/aidial_adapter_vertexai/upstream_config.py
+++ b/aidial_adapter_vertexai/upstream_config.py
@@ -20,8 +20,11 @@ from aidial_adapter_vertexai.utils.log_config import app_logger as log
 
 
 class UpstreamConfig(Protocol):
-    def get_genai_client(self) -> GenAIClient: ...
-    def get_anthropic_client(self) -> AsyncAnthropicVertex | AsyncAnthropic: ...
+    async def get_genai_client(self) -> GenAIClient: ...
+
+    async def get_anthropic_client(
+        self,
+    ) -> AsyncAnthropicVertex | AsyncAnthropic: ...
 
 
 def parse_upstream_config(
@@ -49,10 +52,12 @@ class _ApiKeyUpstreamConfig(BaseModel):
         key = request.headers.get(_UPSTREAM_API_KEY_HEADER_NAME)
         return None if key is None else cls(api_key=key)
 
-    def get_genai_client(self) -> GenAIClient:
+    async def get_genai_client(self) -> GenAIClient:
         return GenAIClient(api_key=self.api_key)
 
-    def get_anthropic_client(self) -> AsyncAnthropicVertex | AsyncAnthropic:
+    async def get_anthropic_client(
+        self,
+    ) -> AsyncAnthropicVertex | AsyncAnthropic:
         return AsyncAnthropic(api_key=self.api_key)
 
 
@@ -94,8 +99,10 @@ class _CloudUpstreamConfig(BaseModel):
 
         return cls.model_validate(conf)
 
-    def get_genai_client(self) -> GenAIClient:
-        return get_genai_client(self.project, self.region)
+    async def get_genai_client(self) -> GenAIClient:
+        return await get_genai_client(self.project, self.region)
 
-    def get_anthropic_client(self) -> AsyncAnthropicVertex | AsyncAnthropic:
-        return get_anthropic_client(self.project, self.region)
+    async def get_anthropic_client(
+        self,
+    ) -> AsyncAnthropicVertex | AsyncAnthropic:
+        return await get_anthropic_client(self.project, self.region)

--- a/aidial_adapter_vertexai/utils/cache.py
+++ b/aidial_adapter_vertexai/utils/cache.py
@@ -23,7 +23,7 @@ class CachedFunction(Protocol, Generic[_P, _R]):
 
 
 def cache(
-    close: Callable[[_R], Coroutine[Any, Any, None]],
+    close: Callable[[_R], Coroutine[Any, Any, None]] | None = None,
 ) -> Callable[[Callable[_P, Coroutine[Any, Any, _R]]], CachedFunction[_P, _R]]:
 
     def wrapper(
@@ -53,7 +53,8 @@ def cache(
                         log.debug(
                             f"Closing cached value ({value}) corresponding to the key {key}."
                         )
-                        await close(value)
+                        if close:
+                            await close(value)
                     self.entries.clear()
 
         return wrapped()

--- a/aidial_adapter_vertexai/utils/cache.py
+++ b/aidial_adapter_vertexai/utils/cache.py
@@ -49,13 +49,18 @@ def cache(
 
             async def clear(self):
                 with self.lock:
-                    for key, value in self.entries.items():
-                        log.debug(
-                            f"Closing cached value ({value}) corresponding to the key {key}."
-                        )
-                        if close:
+                    entries = self.entries
+                    self.entries = {}
+
+                for key, value in entries.items():
+                    log.debug(
+                        f"Closing cached value ({value}) corresponding to the key {key}."
+                    )
+                    if close:
+                        try:
                             await close(value)
-                    self.entries.clear()
+                        except Exception as e:
+                            log.error(f"Error on closing: {e}")
 
         return wrapped()
 

--- a/aidial_adapter_vertexai/utils/cache.py
+++ b/aidial_adapter_vertexai/utils/cache.py
@@ -1,0 +1,61 @@
+import json
+from threading import Lock
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Generic,
+    ParamSpec,
+    Protocol,
+    TypeVar,
+)
+
+from aidial_adapter_vertexai.utils.log_config import app_logger as log
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R", covariant=True)
+
+
+class CachedFunction(Protocol, Generic[_P, _R]):
+    async def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R: ...
+
+    async def clear(self): ...
+
+
+def cache(
+    close: Callable[[_R], Coroutine[Any, Any, None]],
+) -> Callable[[Callable[_P, Coroutine[Any, Any, _R]]], CachedFunction[_P, _R]]:
+
+    def wrapper(
+        f: Callable[_P, Coroutine[Any, Any, _R]],
+    ) -> CachedFunction[_P, _R]:
+        class wrapped:
+            entries: dict[str, _R]
+            lock: Lock
+
+            def __init__(self) -> None:
+                self.entries = {}
+                self.lock = Lock()
+
+            async def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
+                key = json.dumps(
+                    {"args": args, "kwargs": kwargs}, sort_keys=True
+                )
+
+                with self.lock:
+                    if key not in self.entries:
+                        self.entries[key] = await f(*args, **kwargs)
+                    return self.entries[key]
+
+            async def clear(self):
+                with self.lock:
+                    for key, value in self.entries.items():
+                        log.debug(
+                            f"Closing cached value ({value}) corresponding to the key {key}."
+                        )
+                        await close(value)
+                    self.entries.clear()
+
+        return wrapped()
+
+    return wrapper

--- a/aidial_adapter_vertexai/vertex_ai.py
+++ b/aidial_adapter_vertexai/vertex_ai.py
@@ -1,18 +1,18 @@
-from aiocache import cached
 from vertexai.preview.language_models import TextEmbeddingModel
 from vertexai.vision_models import MultiModalEmbeddingModel
 
+from aidial_adapter_vertexai.utils.cache import cache
 from aidial_adapter_vertexai.utils.concurrency import make_single_thread_async
 
 
-@cached()
+@cache()
 async def get_text_embedding_model(model_id: str) -> TextEmbeddingModel:
     return await make_single_thread_async(
         TextEmbeddingModel.from_pretrained, model_id
     )
 
 
-@cached()
+@cache()
 async def get_multi_modal_embedding_model(
     model_id: str,
 ) -> MultiModalEmbeddingModel:

--- a/poetry.lock
+++ b/poetry.lock
@@ -35,23 +35,6 @@ httpx = ["httpx (>=0.25.0,<1)"]
 telemetry = ["opentelemetry-api (>=1.22.0,<2.0)", "opentelemetry-exporter-otlp-proto-grpc (>=1.22.0,<2.0)", "opentelemetry-exporter-prometheus (>=0.43b0)", "opentelemetry-instrumentation-aiohttp-client (>=0.43b0)", "opentelemetry-instrumentation-fastapi (>=0.43b0)", "opentelemetry-instrumentation-httpx (>=0.43b0)", "opentelemetry-instrumentation-logging (>=0.43b0)", "opentelemetry-instrumentation-requests (>=0.43b0)", "opentelemetry-instrumentation-system-metrics (>=0.43b0)", "opentelemetry-instrumentation-urllib (>=0.43b0)", "opentelemetry-sdk (>=1.22.0,<2.0)", "prometheus-client (>=0.17.1,<=0.21)"]
 
 [[package]]
-name = "aiocache"
-version = "0.12.2"
-description = "multi backend asyncio cache"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "aiocache-0.12.2-py2.py3-none-any.whl", hash = "sha256:9b6fa30634ab0bfc3ecc44928a91ff07c6ea16d27d55469636b296ebc6eb5918"},
-    {file = "aiocache-0.12.2.tar.gz", hash = "sha256:b41c9a145b050a5dcbae1599f847db6dd445193b1f3bd172d8e0fe0cb9e96684"},
-]
-
-[package.extras]
-memcached = ["aiomcache (>=0.5.2)"]
-msgpack = ["msgpack (>=0.5.5)"]
-redis = ["redis (>=4.2.0)"]
-
-[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 description = "Happy Eyeballs for asyncio"
@@ -3587,4 +3570,4 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4"
-content-hash = "216ee6c36cb5eda4d1d66559c0ac7426316313c157c9c1b39d3b87b28e516bc6"
+content-hash = "49e33e46b60c14ec99244a36ee05d44bcadacd33645cf25d0dfb625dd2ef291c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,6 @@ env_override_existing_values = 1
 testpaths = ["tests"]
 filterwarnings = [
   "error",
-  # muting warnings like this: ResourceWarning: unclosed <socket.socket fd=13...
-  "ignore::ResourceWarning:",
   # muting warnings from google.rpc https://github.com/googleapis/google-cloud-python/issues/11184 and opentelemetry packages
   "ignore:Deprecated call to `pkg_resources\\.declare_namespace\\('.*'\\):DeprecationWarning",
   "ignore::DeprecationWarning:google.rpc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ openai = "1.107.3"
 anthropic = { version = "0.52.0", extras = ["vertex"] }
 pydantic = "2.10.4"
 uvicorn = "0.22.0"
-aiocache = "0.12.2"
 pillow = "10.3.0"
 pypdf = { version = "6.1.3", extras = ["crypto"] }
 numpy = "2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ env_override_existing_values = 1
 testpaths = ["tests"]
 filterwarnings = [
   "error",
+  # Warning from aiohttp
+  "ignore:Sending a large body directly with raw bytes might lock the event loop. You should probably pass an io.BytesIO object instead:ResourceWarning",
   # muting warnings from google.rpc https://github.com/googleapis/google-cloud-python/issues/11184 and opentelemetry packages
   "ignore:Deprecated call to `pkg_resources\\.declare_namespace\\('.*'\\):DeprecationWarning",
   "ignore::DeprecationWarning:google.rpc",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,12 +46,6 @@ def disable_caches():
     # Disable `aiocache`` caches
     os.environ["AIOCACHE_DISABLE"] = "1"
 
-    # Disable `functools.cache`` caches
-    import aidial_adapter_vertexai.app_config as caches
-
-    caches.get_genai_client.cache_clear()
-    caches.get_anthropic_client.cache_clear()
-
 
 @pytest.fixture()
 async def test_http_client() -> AsyncGenerator[httpx.AsyncClient, None]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 from typing import AsyncGenerator, Mapping
 
 import httpx
@@ -27,24 +26,6 @@ def configure_unit_tests(monkeypatch, request):
         monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "test-creds")
         monkeypatch.setenv("DEFAULT_REGION", DEFAULT_REGION)
         monkeypatch.setenv("GCP_PROJECT_ID", "test-project-id")
-
-
-@pytest.fixture(autouse=True)
-def disable_caches():
-    # Disable all caches that may retain references to event loops.
-    #
-    # pytest-asyncio creates a new event loop for each test with scope="function".
-    # If a cached object is created or a global object is constructed in an early test,
-    # it may hold a reference to that test’s event loop.
-    #
-    # Once that loop is closed and a new one is created for the next test,
-    # the cached object becomes invalid — leading to the error:
-    # "RuntimeError: Event loop is closed"
-    #
-    # To avoid this, we clear or disable any caches that may hold event loop-bound state.
-
-    # Disable `aiocache`` caches
-    os.environ["AIOCACHE_DISABLE"] = "1"
 
 
 @pytest.fixture()

--- a/tests/integration_tests/test_tokenization.py
+++ b/tests/integration_tests/test_tokenization.py
@@ -60,8 +60,6 @@ _CENTRAL = "us-central1"
 _EAST = "us-east5"
 
 chat_deployments: Mapping[ChatCompletionDeployment, str] = {
-    ChatCompletionDeployment.GEMINI_PRO_1_5_V2: _CENTRAL,
-    ChatCompletionDeployment.GEMINI_FLASH_1_5_V2: _CENTRAL,
     ChatCompletionDeployment.GEMINI_2_0_FLASH_LITE_1: _CENTRAL,
     ChatCompletionDeployment.CLAUDE_3_5_SONNET_V2: _EAST,
     ChatCompletionDeployment.CLAUDE_3_5_HAIKU: _EAST,


### PR DESCRIPTION
The test logs are littered with `ResourceWarning: unclosed session/socket` warnings because the clients for the chat and embedding models are never properly closed when the FastAPI application shuts down. This PR fixes this by introducing `cache` decorator with a clean-up action which is called on the FastAPI end of lifespan.

See also for a reference:

* https://github.com/googleapis/python-genai/issues/1343
* https://github.com/googleapis/python-genai/issues/1388