### PR TITLE
fix: relax validation that requires tool definitions

### DIFF
--- a/aidial_adapter_vertexai/chat/gemini/adapter/genai_lib.py
+++ b/aidial_adapter_vertexai/chat/gemini/adapter/genai_lib.py
@@ -197,11 +197,19 @@ class GeminiGenAIChatCompletionAdapter(
         self, params: ModelParameters, prompt: GeminiPromptGenAI
     ) -> AsyncIterator[GenAIGenerateContentResponse]:
         generation_config = await self._get_generation_config(params, prompt)
+        contents = prompt.messages.raw_list
+
+        if log.isEnabledFor(DEBUG):
+            generation_str = json_dumps_short(
+                {"config": generation_config, "contents": contents},
+                exclude_none=True,
+            )
+            log.debug(f"generation: {generation_str}")
 
         if params.stream:
             gen = await self.client.aio.models.generate_content_stream(
                 model=self.model_id,
-                contents=list(prompt.messages.raw_list),
+                contents=list(contents),
                 config=generation_config,
             )
             async for chunk in gen:  # type: ignore
@@ -209,7 +217,7 @@ class GeminiGenAIChatCompletionAdapter(
         else:
             yield await self.client.aio.models.generate_content(
                 model=self.model_id,
-                contents=list(prompt.messages.raw_list),
+                contents=list(contents),
                 config=generation_config,
             )
 
@@ -346,10 +354,10 @@ class GeminiGenAIChatCompletionAdapter(
 
         with Timer("predict timing: {time}", log.debug):
             if log.isEnabledFor(DEBUG):
-                log.debug(
-                    "predict request: "
-                    + json_dumps_short({"parameters": params, "prompt": prompt})
+                request_str = json_dumps_short(
+                    {"parameters": params, "prompt": prompt}, exclude_none=True
                 )
+                log.debug(f"predict request: {request_str}")
 
             completion = ""
             async for content in generate_with_retries(

--- a/aidial_adapter_vertexai/chat/tools.py
+++ b/aidial_adapter_vertexai/chat/tools.py
@@ -142,7 +142,7 @@ class ToolsConfig(BaseModel):
     def from_request(cls, request: AzureChatCompletionRequest) -> Self:
         validate_messages(request)
 
-        tool_ids = collect_tool_ids(request.messages)
+        tool_ids = _collect_tool_ids(request.messages)
 
         if request.functions is not None:
             tools_mode = ToolsMode.FUNCTIONS
@@ -248,44 +248,46 @@ def validate_messages(request: AzureChatCompletionRequest) -> None:
     if decl_functions and decl_tools:
         raise ValidationError("Both functions and tools are not allowed")
 
-    def _warn(msg: str):
+    def warn(msg: str):
         log.warning(
-            f"The request is incomplete. {msg}. The model may misbehave."
+            f"The request is incomplete: {msg}. The model may misbehave."
         )
 
     tool_defs_are_missing = (
-        "the request is missing tool definitions in the `tools` field"
+        "the request is missing tool definitions in the 'tools' field"
     )
     func_defs_are_missing = (
-        "the request is missing function definitions in the `functions` field"
+        "the request is missing function definitions in the 'functions' field"
     )
 
-    for message in request.messages:
-        if message.role == Role.ASSISTANT:
-            use_tools = message.tool_calls is not None
-            if use_tools and not decl_tools:
-                _warn(
-                    f"One of the Assistant messages calls a tool, but {tool_defs_are_missing}"
-                )
+    for idx, message in enumerate(request.messages):
+        if (
+            message.role == Role.ASSISTANT
+            and message.tool_calls is not None
+            and not decl_tools
+        ):
+            warn(
+                f"'messages[{idx}]' is an Assistant message with a tool call, but {tool_defs_are_missing}"
+            )
+        if (
+            message.role == Role.ASSISTANT
+            and message.function_call is not None
+            and not decl_functions
+        ):
+            warn(
+                f"'messages[{idx}]' is an Assistant messages with a function call, but {func_defs_are_missing}"
+            )
+        if message.role == Role.FUNCTION and not decl_functions:
+            warn(
+                f"'messages[{idx}]' is a Function message, but {func_defs_are_missing}"
+            )
+        if message.role == Role.TOOL and not decl_tools:
+            warn(
+                f"'messages[{idx}]' is a Tool message, but {tool_defs_are_missing}"
+            )
 
-            use_functions = message.function_call is not None
-            if use_functions and not decl_functions:
-                _warn(
-                    f"One of the Assistant messages calls a function, but {func_defs_are_missing}"
-                )
-        if message.role == Role.FUNCTION:
-            if not decl_functions:
-                _warn(
-                    f"One of the messages is a Function message, but {func_defs_are_missing}"
-                )
-        if message.role == Role.TOOL:
-            if not decl_tools:
-                _warn(
-                    f"One of the message is a Tool message, but {tool_defs_are_missing}"
-                )
 
-
-def collect_tool_ids(messages: List[Message]) -> Dict[str, str]:
+def _collect_tool_ids(messages: List[Message]) -> Dict[str, str]:
     ret: Dict[str, str] = {}
 
     for message in messages:

--- a/aidial_adapter_vertexai/chat/tools.py
+++ b/aidial_adapter_vertexai/chat/tools.py
@@ -41,6 +41,7 @@ from google.genai.types import ToolDict as GenAITool
 from pydantic.v1 import BaseModel
 
 from aidial_adapter_vertexai.chat.errors import ValidationError
+from aidial_adapter_vertexai.utils.log_config import app_logger as log
 
 
 class ToolsMode(Enum):
@@ -57,24 +58,19 @@ class ToolsConfig(BaseModel):
     List of functions/tools.
     """
 
+    tools_mode: ToolsMode
+
     tool_choice: Literal["auto", "none", "required"] | ToolChoice
 
-    tool_ids: Dict[str, str] | None
+    tool_ids: Dict[str, str]
     """
     Mapping from tool call IDs to corresponding tool names.
-    None means that functions are used, not tools.
+    Empty when there are no tool calls in the messages.
     """
-
-    @property
-    def tools_mode(self) -> ToolsMode:
-        if self.tool_ids is not None:
-            return ToolsMode.TOOLS
-        else:
-            return ToolsMode.FUNCTIONS
 
     @property
     def is_tool(self) -> bool:
-        return self.tool_ids is not None
+        return self.tools_mode == ToolsMode.TOOLS
 
     def not_supported(self) -> None:
         if self.tools:
@@ -84,9 +80,6 @@ class ToolsConfig(BaseModel):
                 raise ValidationError("The functions aren't supported")
 
     def create_fresh_tool_call_id(self, tool_name: str) -> str:
-        if self.tool_ids is None:
-            raise ValidationError("Function are used, but requested tool id")
-
         idx = 1
         while True:
             id = f"{tool_name}_{idx}"
@@ -96,9 +89,6 @@ class ToolsConfig(BaseModel):
             idx += 1
 
     def get_tool_name(self, tool_call_id: str) -> str:
-        if self.tool_ids is None:
-            raise ValidationError("Function are used, but requested tool name")
-
         tool_name = self.tool_ids.get(tool_call_id)
         if tool_name is None:
             raise ValidationError(f"Tool call ID not found: {self.tool_ids}")
@@ -138,7 +128,12 @@ class ToolsConfig(BaseModel):
 
     @classmethod
     def noop(cls) -> Self:
-        return cls(tools=[], tool_choice="auto", tool_ids=None)
+        return cls(
+            tools=[],
+            tool_choice="auto",
+            tool_ids={},
+            tools_mode=ToolsMode.TOOLS,
+        )
 
     def is_empty(self) -> bool:
         return not self.tools
@@ -147,22 +142,27 @@ class ToolsConfig(BaseModel):
     def from_request(cls, request: AzureChatCompletionRequest) -> Self:
         validate_messages(request)
 
+        tool_ids = collect_tool_ids(request.messages)
+
         if request.functions is not None:
+            tools_mode = ToolsMode.FUNCTIONS
             tools = cls._get_tools_from_functions(request.functions)
             tool_choice = cls._function_call_to_tool_choice(
                 request.function_call
             )
-            tool_ids = None
         elif request.tools is not None:
+            tools_mode = ToolsMode.TOOLS
             tools = cls._get_tools_from_functions(request.tools)
             tool_choice = request.tool_choice
-            tool_ids = collect_tool_ids(request.messages)
         else:
-            return cls.noop()
+            tools_mode = ToolsMode.TOOLS
+            tools = []
+            tool_choice = None
 
         return cls(
             tools=tools,
             tool_choice=tool_choice or "auto",
+            tools_mode=tools_mode,
             tool_ids=tool_ids,
         )
 
@@ -248,28 +248,40 @@ def validate_messages(request: AzureChatCompletionRequest) -> None:
     if decl_functions and decl_tools:
         raise ValidationError("Both functions and tools are not allowed")
 
+    def _warn(msg: str):
+        log.warning(
+            f"The request is incomplete. {msg}. The model may misbehave."
+        )
+
+    tool_defs_are_missing = (
+        "the request is missing tool definitions in the `tools` field"
+    )
+    func_defs_are_missing = (
+        "the request is missing function definitions in the `functions` field"
+    )
+
     for message in request.messages:
         if message.role == Role.ASSISTANT:
             use_tools = message.tool_calls is not None
             if use_tools and not decl_tools:
-                raise ValidationError(
-                    "Assistant message uses tools, but tools are not declared"
+                _warn(
+                    f"One of the Assistant messages calls a tool, but {tool_defs_are_missing}"
                 )
 
             use_functions = message.function_call is not None
             if use_functions and not decl_functions:
-                raise ValidationError(
-                    "Assistant message uses functions, but functions are not declared"
+                _warn(
+                    f"One of the Assistant messages calls a function, but {func_defs_are_missing}"
                 )
         if message.role == Role.FUNCTION:
             if not decl_functions:
-                raise ValidationError(
-                    "Function message is used, but functions are not declared"
+                _warn(
+                    f"One of the messages is a Function message, but {func_defs_are_missing}"
                 )
         if message.role == Role.TOOL:
             if not decl_tools:
-                raise ValidationError(
-                    "Tool message is used, but tools are not declared"
+                _warn(
+                    f"One of the message is a Tool message, but {tool_defs_are_missing}"
                 )
 
 

--- a/tests/integration_tests/test_chat_completion_generation.py
+++ b/tests/integration_tests/test_chat_completion_generation.py
@@ -15,10 +15,12 @@ from tests.utils.openai import (
     ChatCompletionArgs,
     ChatCompletionResult,
     ai,
+    ai_tools,
     chat_completion,
     function_to_tool,
     sanitize_test_name,
     sys,
+    tool_response,
     user,
     user_with_attachment_data,
     user_with_attachment_url,
@@ -606,7 +608,49 @@ async def test_tool_call_zero_parameters(chat: Chat):
 
     tool_calls = response.tool_calls
     assert tool_calls is not None, "Tool calls are missing"
-    assert tool_calls[0].function.name == "get_current_time"
+    assert tool_calls[0].type == "function"
+    function = tool_calls[0].function
+    assert function.name == "get_current_time"
+    assert function.arguments == "{}"
+    assert response.finish_reasons == ["tool_calls"]
+
+
+@pytest.mark.parametrize(
+    "deployment",
+    select(pred(supports_tools), deployments),
+    ids=display_deployment,
+)
+async def test_tool_calls_without_tool_definitions(deployment: D, chat: Chat):
+    if deployment == D.CLAUDE_3_OPUS:
+        pytest.skip(
+            "Claude 3 Opus doesn't handle well inconsistent requests. "
+            "It finishes with the stop reason `stop_sequence` where stop "
+            "sequence is `<antml:function_calls>` which is a keyword from the Anthropic Claude system prompt."
+        )
+
+    response = await chat(
+        messages=[
+            user("what time is it?"),
+            ai_tools(
+                [
+                    {
+                        "type": "function",
+                        "id": "tool-call-id1",
+                        "function": {
+                            "name": "get_current_time",
+                            "arguments": "{}",
+                        },
+                    }
+                ]
+            ),
+            tool_response(id="tool-call-id1", content="01:22 AM"),
+            ai("It's 01:22 AM"),
+            user("Now compute (2+3). Reply with a single digit"),
+        ],
+    )
+
+    assert "5" in response.content
+    assert response.finish_reasons == ["stop"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The following chat completion request is failing with the error `422 Assistant message uses tools, but tools are not declared`:

```json
{
  "model": "gemini-2.5-pro",
  "messages": [
    {"role": "user", "content": "what time is it?"},
    {"role": "assistant", "tool_calls": [
                    {
                        "type": "function",
                        "id": "tool-call-id1",
                        "function": {
                            "name": "get_current_time",
                            "arguments": "{}"
                        }
                    }
                ]
    },
    {"role": "tool", "tool_call_id": "tool-call-id1", "content": "01:22 AM"},
    {"role": "assistant", "content": "It's 01:22 AM"},
    {"role": "user", "content": "Now compute (2+3). Reply with a single digit"}
  ]
}
```

The fix turns the errors into warnings with friendlier messages such as 

> WARNING: The request is incomplete: 'messages[3]' is an Assistant message with a tool call, but the request is missing tool definitions in the 'tools' field. The model may misbehave.

Gemini and Claude models seem to tolerate such requests just fine; however, it may not be the case for future models. 
Now it is on the client to deal with an unexpected behaviour from the upstream model.