### PR TITLE
chore: fix security issues with `setuptools` and `wheel` packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,10 @@ FROM python:3.11-alpine3.20 AS server
 RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
 # fix CVE-2023-52425
 RUN apk upgrade --no-cache libexpat
-# fix CVE-2025-47273
-RUN pip install "setuptools==78.1.1"
+# fix CVE-2026-23949
+RUN pip install setuptools==80.10.2
+# fix CVE-2026-24049
+RUN pip install wheel==0.46.2
 
 WORKDIR /app
 


### PR DESCRIPTION
Fixes CVE-2026-23949 [alerts](https://github.com/epam/ai-dial-adapter-vertexai/security/code-scanning?query=wheel-0.45.1+branch%3Adevelopment+)
Fixes CVE-2026-24049 [alerts](https://github.com/epam/ai-dial-adapter-vertexai/security/code-scanning?query=jaraco.context-5.3.0+branch%3Adevelopment+)
