### PR TITLE
feat: Gemini: improve mapping of reasoning_effort parameter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,7 @@
     "."
   ],
   "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true
+  "python.testing.pytestEnabled": true,
+  "python-envs.defaultEnvManager": "ms-python.python:poetry",
+  "python-envs.defaultPackageManager": "ms-python.python:poetry"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,5 @@
     "."
   ],
   "python.testing.unittestEnabled": false,
-  "python.testing.pytestEnabled": true,
-  "python-envs.defaultEnvManager": "ms-python.python:poetry",
-  "python-envs.defaultPackageManager": "ms-python.python:poetry"
+  "python.testing.pytestEnabled": true
 }

--- a/aidial_adapter_vertexai/chat/gemini/input.py
+++ b/aidial_adapter_vertexai/chat/gemini/input.py
@@ -15,9 +15,13 @@ def to_genai_thinking_level(
     match reasoning_effort:
         case None | ReasoningEffort.NONE:
             return None
-        case ReasoningEffort.MINIMAL | ReasoningEffort.LOW:
+        case ReasoningEffort.MINIMAL:
+            return ThinkingLevel.MINIMAL
+        case ReasoningEffort.LOW:
             return ThinkingLevel.LOW
-        case ReasoningEffort.MEDIUM | ReasoningEffort.HIGH:
+        case ReasoningEffort.MEDIUM:
+            return ThinkingLevel.MEDIUM
+        case ReasoningEffort.HIGH:
             return ThinkingLevel.HIGH
         case _:
             assert_never(reasoning_effort)


### PR DESCRIPTION
Gemini API introduced minimal and medium reasoning efforts: https://github.com/googleapis/python-genai/commit/96d644cd52a300063040c6d7bf70e2939b735e6f
So we can how map OpenAI's level to Gemini's one-to-one.

See also which levels which Gemini model supports here: https://ai.google.dev/gemini-api/docs/thinking#thinking-levels