### PR TITLE
fix: fix deadlock in the cache function

### DIFF
--- a/aidial_adapter_vertexai/utils/cache.py
+++ b/aidial_adapter_vertexai/utils/cache.py
@@ -1,14 +1,6 @@
+import asyncio
 import json
-from threading import Lock
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    Generic,
-    ParamSpec,
-    Protocol,
-    TypeVar,
-)
+from typing import Awaitable, Callable, Generic, ParamSpec, Protocol, TypeVar
 
 from aidial_adapter_vertexai.utils.log_config import app_logger as log
 
@@ -16,39 +8,36 @@ _P = ParamSpec("_P")
 _R = TypeVar("_R", covariant=True)
 
 
-class CachedFunction(Protocol, Generic[_P, _R]):
+class _CachedFunction(Protocol, Generic[_P, _R]):
     async def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R: ...
-
     async def clear(self): ...
 
 
 def cache(
-    close: Callable[[_R], Coroutine[Any, Any, None]] | None = None,
-) -> Callable[[Callable[_P, Coroutine[Any, Any, _R]]], CachedFunction[_P, _R]]:
+    close: Callable[[_R], Awaitable[None]] | None = None,
+) -> Callable[[Callable[_P, Awaitable[_R]]], _CachedFunction[_P, _R]]:
 
-    def wrapper(
-        f: Callable[_P, Coroutine[Any, Any, _R]],
-    ) -> CachedFunction[_P, _R]:
+    def wrapper(f: Callable[_P, Awaitable[_R]]) -> _CachedFunction[_P, _R]:
         class wrapped:
             entries: dict[str, _R]
-            lock: Lock
+            lock: asyncio.Lock
 
             def __init__(self) -> None:
                 self.entries = {}
-                self.lock = Lock()
+                self.lock = asyncio.Lock()
 
             async def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
                 key = json.dumps(
                     {"args": args, "kwargs": kwargs}, sort_keys=True
                 )
 
-                with self.lock:
+                async with self.lock:
                     if key not in self.entries:
                         self.entries[key] = await f(*args, **kwargs)
                     return self.entries[key]
 
             async def clear(self):
-                with self.lock:
+                async with self.lock:
                     entries = self.entries
                     self.entries = {}
 

--- a/aidial_adapter_vertexai/utils/cache.py
+++ b/aidial_adapter_vertexai/utils/cache.py
@@ -53,8 +53,8 @@ def cache(
                     entries = self._tasks
                     self._tasks = {}
 
-                if close is None:
-                    return
+                func_name = f"{f.__module__}.{f.__qualname__}"
+                log.debug(f"Clearing cache {func_name}")
 
                 for key, task in entries.items():
                     try:
@@ -62,11 +62,11 @@ def cache(
                     except Exception:
                         continue
 
-                    func_name = f"{f.__module__}.{f.__qualname__}"
-                    log.debug(f"Closing cached value for {func_name}({key})")
+                    log.debug(f"Closing cached value {func_name}({key})")
 
                     try:
-                        await close(value)
+                        if close is not None:
+                            await close(value)
                     except Exception as e:
                         log.error(f"Error on closing the task: {e}")
 

--- a/aidial_adapter_vertexai/utils/cache.py
+++ b/aidial_adapter_vertexai/utils/cache.py
@@ -18,7 +18,6 @@ def cache(
 ) -> Callable[
     [Callable[_P, Coroutine[None, None, _R]]], _CachedFunction[_P, _R]
 ]:
-
     def wrapper(
         f: Callable[_P, Coroutine[None, None, _R]],
     ) -> _CachedFunction[_P, _R]:
@@ -37,7 +36,7 @@ def cache(
 
                 async with self._lock:
                     if (task := self._tasks.get(key)) is None:
-                        task = self._tasks[key] = asyncio.Task(
+                        task = self._tasks[key] = asyncio.create_task(
                             f(*args, **kwargs)
                         )
 

--- a/aidial_adapter_vertexai/utils/cache.py
+++ b/aidial_adapter_vertexai/utils/cache.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from typing import Awaitable, Callable, Generic, ParamSpec, Protocol, TypeVar
+from typing import Callable, Coroutine, Generic, ParamSpec, Protocol, TypeVar
 
 from aidial_adapter_vertexai.utils.log_config import app_logger as log
 
@@ -14,42 +14,62 @@ class _CachedFunction(Protocol, Generic[_P, _R]):
 
 
 def cache(
-    close: Callable[[_R], Awaitable[None]] | None = None,
-) -> Callable[[Callable[_P, Awaitable[_R]]], _CachedFunction[_P, _R]]:
+    close: Callable[[_R], Coroutine[None, None, None]] | None = None,
+) -> Callable[
+    [Callable[_P, Coroutine[None, None, _R]]], _CachedFunction[_P, _R]
+]:
 
-    def wrapper(f: Callable[_P, Awaitable[_R]]) -> _CachedFunction[_P, _R]:
+    def wrapper(
+        f: Callable[_P, Coroutine[None, None, _R]],
+    ) -> _CachedFunction[_P, _R]:
         class wrapped:
-            entries: dict[str, _R]
-            lock: asyncio.Lock
+            _tasks: dict[str, asyncio.Task[_R]]
+            _lock: asyncio.Lock
 
             def __init__(self) -> None:
-                self.entries = {}
-                self.lock = asyncio.Lock()
+                self._tasks = {}
+                self._lock = asyncio.Lock()
 
             async def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
                 key = json.dumps(
                     {"args": args, "kwargs": kwargs}, sort_keys=True
                 )
 
-                async with self.lock:
-                    if key not in self.entries:
-                        self.entries[key] = await f(*args, **kwargs)
-                    return self.entries[key]
+                async with self._lock:
+                    if (task := self._tasks.get(key)) is None:
+                        task = self._tasks[key] = asyncio.Task(
+                            f(*args, **kwargs)
+                        )
+
+                try:
+                    return await task
+                except Exception:
+                    async with self._lock:
+                        if self._tasks.get(key) is task:
+                            del self._tasks[key]
+                    raise
 
             async def clear(self):
-                async with self.lock:
-                    entries = self.entries
-                    self.entries = {}
+                async with self._lock:
+                    entries = self._tasks
+                    self._tasks = {}
 
-                for key, value in entries.items():
-                    log.debug(
-                        f"Closing cached value ({value}) corresponding to the key {key}."
-                    )
-                    if close:
-                        try:
-                            await close(value)
-                        except Exception as e:
-                            log.error(f"Error on closing: {e}")
+                if close is None:
+                    return
+
+                for key, task in entries.items():
+                    try:
+                        value = task.result()
+                    except Exception:
+                        continue
+
+                    func_name = f"{f.__module__}.{f.__qualname__}"
+                    log.debug(f"Closing cached value for {func_name}({key})")
+
+                    try:
+                        await close(value)
+                    except Exception as e:
+                        log.error(f"Error on closing the task: {e}")
 
         return wrapped()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ filterwarnings = [
   "ignore::DeprecationWarning:google.rpc",
   "ignore::DeprecationWarning:opentelemetry.instrumentation.dependencies",
   "ignore:Inheritance class AiohttpClientSession from ClientSession is discouraged:DeprecationWarning",
+  # vertexai is deprecated; remove it once this is fixed:
+  # https://github.com/epam/ai-dial-adapter-vertexai/issues/398
+  "ignore:This feature is deprecated as of June 24:UserWarning",
 ]
 
 [tool.pyright]

--- a/tests/unit_tests/test_cache.py
+++ b/tests/unit_tests/test_cache.py
@@ -1,0 +1,20 @@
+import asyncio
+import time
+
+from aidial_adapter_vertexai.utils.cache import cache
+from aidial_adapter_vertexai.utils.concurrency import make_single_thread_async
+
+
+@cache()
+async def _long_running_task(key: str) -> int:
+    def _task(_dummy) -> int:
+        time.sleep(2)
+        return 10
+
+    return await make_single_thread_async(_task, ())
+
+
+async def test_concurrent_fetches_to_the_same_cache():
+    n = 10
+    results = await asyncio.gather(*[_long_running_task("x") for _ in range(n)])
+    assert len(results) == n

--- a/tests/unit_tests/test_cache.py
+++ b/tests/unit_tests/test_cache.py
@@ -1,20 +1,298 @@
 import asyncio
-import time
+from typing import Any
+
+import pytest
 
 from aidial_adapter_vertexai.utils.cache import cache
-from aidial_adapter_vertexai.utils.concurrency import make_single_thread_async
 
 
-@cache()
-async def _long_running_task(key: str) -> int:
-    def _task(_dummy) -> int:
-        time.sleep(2)
+async def test_concurrent_calls_same_key_are_single_flight():
+    calls = 0
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    @cache()
+    async def f(key: str) -> int:
+        nonlocal calls
+        calls += 1
+        entered.set()
+        await release.wait()
         return 10
 
-    return await make_single_thread_async(_task, ())
+    tasks = [asyncio.create_task(f("x")) for _ in range(10)]
+
+    await entered.wait()
+
+    assert calls == 1
+
+    release.set()
+    results = await asyncio.gather(*tasks)
+
+    assert results == [10] * 10
+    assert calls == 1
 
 
-async def test_concurrent_fetches_to_the_same_cache():
-    n = 10
-    results = await asyncio.gather(*[_long_running_task("x") for _ in range(n)])
-    assert len(results) == n
+async def test_sequential_calls_same_key_use_cached_value():
+    calls = 0
+
+    @cache()
+    async def f(key: str) -> int:
+        nonlocal calls
+        calls += 1
+        return 42
+
+    assert await f("x") == 42
+    assert await f("x") == 42
+    assert await f("x") == 42
+    assert calls == 1
+
+
+async def test_different_keys_are_computed_independently():
+    calls: list[str] = []
+
+    @cache()
+    async def f(key: str) -> str:
+        calls.append(key)
+        await asyncio.sleep(0.01)
+        return f"value:{key}"
+
+    results = await asyncio.gather(
+        f("a"),
+        f("b"),
+        f("a"),
+        f("c"),
+        f("b"),
+    )
+
+    assert results == [
+        "value:a",
+        "value:b",
+        "value:a",
+        "value:c",
+        "value:b",
+    ]
+    assert calls.count("a") == 1
+    assert calls.count("b") == 1
+    assert calls.count("c") == 1
+
+
+async def test_kwargs_order_does_not_change_cache_key():
+    calls = 0
+
+    @cache()
+    async def f(*, a: int, b: int) -> int:
+        nonlocal calls
+        calls += 1
+        return a + b
+
+    assert await f(a=1, b=2) == 3
+    assert await f(b=2, a=1) == 3
+    assert calls == 1
+
+
+async def test_args_are_part_of_cache_key():
+    calls = 0
+
+    @cache()
+    async def f(a: int, b: int) -> int:
+        nonlocal calls
+        calls += 1
+        return 10 * a + b
+
+    assert await f(1, 2) == 12
+    assert await f(2, 1) == 21
+    assert calls == 2
+
+
+async def test_exception_is_not_cached():
+    calls = 0
+
+    @cache()
+    async def f(key: str) -> int:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError(f"boom:{key}:{calls}")
+
+    with pytest.raises(RuntimeError, match=r"boom:x:1"):
+        await f("x")
+
+    with pytest.raises(RuntimeError, match=r"boom:x:2"):
+        await f("x")
+
+    assert calls == 2
+
+
+async def test_concurrent_waiters_for_same_failing_key_see_same_exception_instance():
+    calls = 0
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    @cache()
+    async def f(key: str) -> int:
+        nonlocal calls
+        calls += 1
+        entered.set()
+        await release.wait()
+        raise ValueError("boom")
+
+    tasks = [asyncio.create_task(f("x")) for _ in range(5)]
+
+    await entered.wait()
+    assert calls == 1
+
+    release.set()
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    assert all(isinstance(x, ValueError) for x in results)
+    assert all(str(x) == "boom" for x in results)
+    assert calls == 1
+
+
+async def test_clear_removes_cached_entries():
+    calls = 0
+
+    @cache()
+    async def f(key: str) -> str:
+        nonlocal calls
+        calls += 1
+        return f"v:{key}:{calls}"
+
+    assert await f("x") == "v:x:1"
+    assert await f("x") == "v:x:1"
+    assert calls == 1
+
+    await f.clear()
+
+    assert await f("x") == "v:x:2"
+    assert calls == 2
+
+
+async def test_clear_calls_close_for_resolved_values():
+    closed: list[str] = []
+
+    async def close(value: str):
+        closed.append(value)
+
+    @cache(close=close)
+    async def f(key: str) -> str:
+        return f"value:{key}"
+
+    assert await f("a") == "value:a"
+    assert await f("b") == "value:b"
+    assert await f("a") == "value:a"
+
+    await f.clear()
+
+    assert sorted(closed) == ["value:a", "value:b"]
+
+
+async def test_clear_on_empty_cache_is_noop():
+    closed: list[Any] = []
+
+    async def close(value: Any):
+        closed.append(value)
+
+    @cache(close=close)
+    async def f(key: str) -> str:
+        return key
+
+    await f.clear()
+    assert closed == []
+
+
+async def test_clear_does_not_close_failed_entries():
+    closed: list[str] = []
+
+    async def close(value: str):
+        closed.append(value)
+
+    @cache(close=close)
+    async def f(key: str) -> str:
+        if key == "bad":
+            raise RuntimeError("boom")
+        return f"value:{key}"
+
+    assert await f("ok") == "value:ok"
+    with pytest.raises(RuntimeError, match="boom"):
+        await f("bad")
+
+    await f.clear()
+
+    assert closed == ["value:ok"]
+
+
+async def test_clear_does_not_close_pending_entries():
+    closed: list[str] = []
+    release = asyncio.Event()
+
+    async def close(value: str):
+        closed.append(value)
+
+    @cache(close=close)
+    async def f(key: str) -> str:
+        await release.wait()
+        return f"value:{key}"
+
+    task = asyncio.create_task(f("x"))
+
+    await f.clear()
+    assert closed == []
+
+    release.set()
+    assert await task == "value:x"
+
+
+async def test_different_decorated_functions_have_independent_caches():
+    calls_f = 0
+    calls_g = 0
+
+    @cache()
+    async def f(key: str) -> str:
+        nonlocal calls_f
+        calls_f += 1
+        return f"f:{key}"
+
+    @cache()
+    async def g(key: str) -> str:
+        nonlocal calls_g
+        calls_g += 1
+        return f"g:{key}"
+
+    assert await f("x") == "f:x"
+    assert await f("x") == "f:x"
+    assert await g("x") == "g:x"
+    assert await g("x") == "g:x"
+
+    assert calls_f == 1
+    assert calls_g == 1
+
+
+async def test_same_key_after_clear_recomputes_once_under_concurrency() -> None:
+    calls = 0
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    @cache()
+    async def f(key: str) -> int:
+        nonlocal calls, entered, release
+        calls += 1
+        entered.set()
+        await release.wait()
+        return calls
+
+    for gen in [1, 2]:
+        await f.clear()
+
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        tasks = [asyncio.create_task(f("x")) for _ in range(5)]
+
+        await entered.wait()
+        assert calls == gen
+
+        release.set()
+        results = await asyncio.gather(*tasks)
+
+        assert results == [gen] * 5
+        assert calls == gen


### PR DESCRIPTION
Before the fix, concurrent requests to embedding models for the first time _(cache warming)_ caused a deadlock in the `cache` decorator helper.