### PR TITLE
fix: remove dead code in finish_reason.py and add ImageConfig test

### DIFF
--- a/aidial_adapter_vertexai/chat/gemini/finish_reason.py
+++ b/aidial_adapter_vertexai/chat/gemini/finish_reason.py
@@ -56,10 +56,4 @@ def genai_to_openai_finish_reason(
                 retriable=retriable,
             )
         case _:
-            raise FinishReasonOtherError(
-                msg=_add_finish_message(
-                    f"Unexpected finish reason: {finish_reason.value}"
-                ),
-                retriable=retriable,
-            )
             assert_never(finish_reason)

--- a/tests/unit_tests/test_image_configuration.py
+++ b/tests/unit_tests/test_image_configuration.py
@@ -1,0 +1,14 @@
+from aidial_adapter_vertexai.chat.gemini.adapter import ImageConfig
+
+
+def test_gemini_extra_fields_in_image_config():
+    config_source = {
+        "aspect_ratio": "16:9",
+        "image_size": "2K",
+        "foo": "bar",  # extra fields are preserved
+    }
+
+    config_obj = ImageConfig.model_validate(config_source)
+    config_dict = config_obj.to_image_config()
+
+    assert config_dict == config_source


### PR DESCRIPTION
- Remove unreachable assert_never call after raise in genai_to_openai_finish_reason's catch-all case branch. The raise statement prevents assert_never from ever executing. Keep assert_never as the sole handler for exhaustiveness checking.

- Add unit test for ImageConfig mirroring existing ThinkingConfig test pattern to verify extra fields are preserved through model_validate and to_image_config round-trip.



### Description of changes

**1. Dead code removal**
In [genai_to_openai_finish_reason](cci:1://file:///Users/adem/Documents/4-Projeler/github_projects/contributions/ai-dial-adapter-vertexai/aidial_adapter_vertexai/chat/gemini/finish_reason.py:13:0-58:39), the catch-all `case _:` branch had an `assert_never` call placed after a `raise FinishReasonOtherError(...)`. Since `raise` immediately exits the function, the `assert_never` line was unreachable dead code.
The fix removes the `raise` and keeps `assert_never` as the sole handler. `assert_never` provides both compile-time exhaustiveness checking (via type checkers like pyright) and a clear runtime `TypeError` if an unhandled enum value is encountered.
**2. Add unit test for [ImageConfig](cci:2://file:///Users/adem/Documents/4-Projeler/github_projects/contributions/ai-dial-adapter-vertexai/aidial_adapter_vertexai/chat/gemini/adapter.py:63:0-88:54)**
[ThinkingConfig](cci:2://file:///Users/adem/Documents/4-Projeler/github_projects/contributions/ai-dial-adapter-vertexai/aidial_adapter_vertexai/chat/gemini/adapter.py:91:0-108:54) has a unit test that verifies extra fields are preserved through `model_validate` → [to_thinking_config()](cci:1://file:///Users/adem/Documents/4-Projeler/github_projects/contributions/ai-dial-adapter-vertexai/aidial_adapter_vertexai/chat/gemini/adapter.py:103:4-108:54) round-trip. The structurally identical [ImageConfig](cci:2://file:///Users/adem/Documents/4-Projeler/github_projects/contributions/ai-dial-adapter-vertexai/aidial_adapter_vertexai/chat/gemini/adapter.py:63:0-88:54) class had no such test.
Added a matching test to verify `ImageConfig.model_validate()` and [to_image_config()](cci:1://file:///Users/adem/Documents/4-Projeler/github_projects/contributions/ai-dial-adapter-vertexai/aidial_adapter_vertexai/chat/gemini/adapter.py:83:4-88:54) correctly preserve both known fields (`aspect_ratio`, `image_size`) and extra fields.
### Checklist
- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.