### PR TITLE
fix: Gemini 3: support tool call messages with non-empty content

### DIFF
--- a/aidial_adapter_vertexai/chat/gemini/state.py
+++ b/aidial_adapter_vertexai/chat/gemini/state.py
@@ -1,7 +1,6 @@
 import pydantic
 from aidial_sdk.chat_completion import Message as DialMessage
 from google.genai.types import Content as GenAIContent
-from google.genai.types import Part as GenAIPart
 from pydantic import BaseModel
 
 from aidial_adapter_vertexai.utils.log_config import app_logger as log
@@ -19,31 +18,86 @@ class Part(_StateModel):
 
     thought_signature: bytes | None = None
 
-    def update(self, part: GenAIPart) -> None:
-        part.thought_signature = (
-            part.thought_signature or self.thought_signature
-        )
-
 
 class Content(_StateModel):
     """Structurally mirrors GenAIContent"""
 
     parts: list[Part] | None = None
 
-    def update(self, content: GenAIContent) -> None:
-        if self.parts and (parts := content.parts):
-            for i in range(min(len(self.parts), len(parts))):
-                self.parts[i].update(parts[i])
-
 
 class MessageState(_StateModel):
     gemini_message_content: Content | None = None
 
     def set_thought_signature(self, thought_signature: bytes) -> None:
-        if not self.gemini_message_content:
-            self.gemini_message_content = Content(
-                parts=[Part(thought_signature=thought_signature)]
+        if self.gemini_message_content:
+            log.warning(
+                "Multiple thought_signature's were received within a single Gemini response. "
+                "Only the first one will be taken into account."
             )
+            return
+
+        self.gemini_message_content = Content(
+            parts=[Part(thought_signature=thought_signature)]
+        )
+
+    def _get_thought_signature(self) -> bytes | None:
+        if self.gemini_message_content is None:
+            return None
+
+        parts = self.gemini_message_content.parts
+        if parts is None or len(parts) == 0:
+            return None
+
+        if len(parts) > 1:
+            log.warning(
+                "Multiple thought_signature's were received within a single assistant message. "
+                "Only the first one will be taken into account."
+            )
+        return parts[0].thought_signature
+
+    def _disable_thought_signature_validation(self, content: GenAIContent):
+        for part in content.parts or []:
+            if part.function_call:
+                part.thought_signature = b"skip_thought_signature_validator"
+                log.warning(
+                    "Cannot find thought_signature for a function call block. "
+                    "Defaulting to a fake thought_signature."
+                )
+                return
+
+    def _set_thought_signature(
+        self, content: GenAIContent, thought_signature: bytes
+    ):
+        content_parts = content.parts or []
+
+        # Attach to the first function block if there are any
+        for part in content_parts:
+            if part.function_call:
+                part.thought_signature = thought_signature
+                return
+
+        # Otherwise, attach to the last block
+        if not content_parts:
+            content_parts[-1].thought_signature = thought_signature
+
+    def update_content(self, content: GenAIContent):
+        """
+        As per documentation:
+        https://docs.cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures/#using-rest-or-manual-handling
+        The thought_signature's are integrated to the content blocks in the following way:
+
+        1. If there are no thought_signature's and there are function blocks, then it will result in
+            the 400 error from the upstream: content block is missing a `thought_signature`.
+            Therefore, we guard against it by setting a fake signature to relax this validation.
+        2. If there are any function call blocks, attach the thought signature to the *first* function block.
+        3. If there are no function call blocks, attach the thought signature to the *last* block.
+        """
+        thought_signature = self._get_thought_signature()
+
+        if thought_signature is None:
+            self._disable_thought_signature_validation(content)
+        else:
+            self._set_thought_signature(content, thought_signature)
 
     def to_json(self) -> dict:
         return self.model_dump(exclude_none=True, mode="json")
@@ -51,7 +105,7 @@ class MessageState(_StateModel):
 
 def _parse_message_content_from_state(
     idx: int, message: DialMessage
-) -> MessageState | None:
+) -> MessageState:
     if (cc := message.custom_content) and (state := cc.state):
         try:
             return MessageState.model_validate(state)
@@ -60,19 +114,11 @@ def _parse_message_content_from_state(
                 f"Invalid state at the path 'messages[{idx}].custom_content.state': {e}"
             )
 
-    return None
+    return MessageState()
 
 
 def update_with_message_state(
     idx: int, message: DialMessage, content: GenAIContent
 ):
     state = _parse_message_content_from_state(idx, message)
-
-    if state and state.gemini_message_content:
-        state.gemini_message_content.update(content)
-    else:
-        for part in content.parts or []:
-            if part.function_call is not None:
-                # Last resort if thought_signature wasn't provided in the state
-                part.thought_signature = b"skip_thought_signature_validator"
-                break
+    state.update_content(content)

--- a/aidial_adapter_vertexai/chat/gemini/state.py
+++ b/aidial_adapter_vertexai/chat/gemini/state.py
@@ -73,6 +73,6 @@ def update_with_message_state(
     else:
         for part in content.parts or []:
             if part.function_call is not None:
-                # Last resort if thought_signature wasn't provided via state
+                # Last resort if thought_signature wasn't provided in the state
                 part.thought_signature = b"skip_thought_signature_validator"
                 break

--- a/tests/integration_tests/test_chat_completion_generation.py
+++ b/tests/integration_tests/test_chat_completion_generation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Awaitable, Callable
-from typing import Protocol, Unpack
+from typing import Literal, Protocol, Unpack
 from unittest.mock import patch
 
 import anthropic
@@ -869,7 +869,16 @@ async def test_tool_response(test: ToolCallTest, chat: Chat):
     select(pred(supports_tools), deployments),
     ids=display_deployment,
 )
-async def test_tool_call_and_response(deployment: D, chat: Chat):
+@pytest.mark.parametrize(
+    "tool_call_content",
+    ["I need to call the tool", "", " ", "missing", None],
+    ids=["non_empty", "empty_string", "single_space", "missing", "none"],
+)
+async def test_tool_call_and_response(
+    deployment: D,
+    tool_call_content: str | Literal["missing"] | None,
+    chat: Chat,
+):
     messages: list[ChatCompletionMessageParam] = [
         user("Tell me what's the temperature in London, UK in celsius?"),
     ]
@@ -885,7 +894,12 @@ async def test_tool_call_and_response(deployment: D, chat: Chat):
 
     response_message = response.response.choices[0].message.to_dict()
 
-    if deployment == D.GEMINI_3_PRO_PREVIEW:
+    if tool_call_content == "missing":
+        response_message.pop("content", None)
+    else:
+        response_message["content"] = tool_call_content
+
+    if is_gemini_3(deployment):
         dial_message = DialMessage.model_validate(response_message)
         state = _parse_message_content_from_state(0, dial_message)
         assert state is not None, "state is missing"


### PR DESCRIPTION
### Before the fix

The following request to Gemini 3 models led to 400 error coming from the upstream:

<details> <summary>Chat completions request</summary>

```json
{
  "model": "gemini-3.1-pro-preview",
  "messages": [
    {
      "role": "user",
      "content": "Tell me what's the temperature in London, UK in celsius?"
    },
    {
      "content": "I need to call the tool",
      "role": "assistant",
      "tool_calls": [
        {
          "id": "get_temperature_1",
          "function": {
            "arguments": "{\"location\": \"London, UK\", \"unit\": \"celsius\"}",
            "name": "get_temperature"
          },
          "type": "function"
        }
      ],
      "custom_content": {
        "state": {
          "gemini_message_content": {
            "parts": [
              {
                "thought_signature": "CjIBjz1rXxJBI0KKATei4HC_d_7PE-BuVVKnjood4z5s9BsVfTvFTobzmeh_T331sbiGCgp8AY89a1_T1RGsfv75AZSpkU2DZ7f1-JqWaJScJvUNRGBY0b0R9-pC1yHzFAMxyXbgKeKhZmkfHGqrLa8jEKUKTvOYaZjJ3g53waOxHBzGsco5Ci7pXm7QQWl4Bkrrazw3GweI6Fs8j8NzVqAdEq9jS7NHDxeKpyYp4O1F1AqOAQGPPWtfhwKJ-Z5h__f7CKyqU9hqibqSxvuvMytzfCLbn4JBT_JafOKqJgMo33ttGLSlqjhYt_t4A6ejx0zxVg5zGUVsJLABVg87DC6EIEBzJAadg1EmRGzri3WftZvDxTaJZiF2_fgbaY5Juwb72t351w_4q2wc-gLwVlSGJNY79ML-diHIz3qfRBPIfCsKfQGPPWtfGa9U6pi0XYbUFP9xnDt03zHEJi0zblr_xEq8Y_4Coa8vnmqYNLDEAHORSHtIdWNZO5Ze_z9sev3ItGDGW7IrG-owV0AkG8yzj2RmNZ085-ez4WRov7IU5MTxPLJGaTQEpYuKJiuulU39bBj6Z010_ej69SaI90eZCnMBjz1rXw9ij2hMrlXtujUmnHesUZeXYLiElc8-quE217wvJi_LfxpeYXZbHyDykw_Sui6hc8yHul8G11wAiO85REieVnxx2IRDp3HPPE-HnLUeZnABRH2sP61MU4R5tfAFpcyOrJb_EoWln5qDDc3YBwQnCm4Bjz1rX60QVUerHLa5YayfNk0rbE9vqxjIP2F-msLbScmMQIqrdUn-yg48vVNQguAxBWJC2l6XHWATic7c7YDB1JferFI6HWTY7430Qc5barnPZK8pfF697EztNK4BzHK8aTSBHLH5-e27NkuPvgpaAY89a1_iGx-Snc6kM0QuiG77ZzWtvZmtKcUcuUGkMwyirLhmYyUBKahBV1tO3I_A7y0-pTG8VScLIP8EW0NKxZ7MVjzFWhnBflAstmM0j01B11ejVnPRRgXN"
              }
            ]
          }
        }
      }
    },
    {
      "role": "tool",
      "tool_call_id": "get_temperature_1",
      "content": "it's 20 degrees celsius"
    }
  ],
  "stream": true,
  "tools": [
    {
      "type": "function",
      "function": {
        "name": "get_temperature",
        "description": "Get reliable information about the temperature in the given city",
        "strict": true,
        "parameters": {
          "type": "object",
          "properties": {
            "location": {
              "type": "string",
              "description": "The city, e.g. San Francisco"
            },
            "unit": {
              "type": "string",
              "enum": [
                "celsius",
                "fahrenheit"
              ],
              "description": "The temperature unit to use. Infer this from the location."
            }
          },
          "required": [
            "location",
            "unit"
          ],
          "additionalProperties": false
        }
      }
    }
  ]
}
```

</details>

400 Error:

> {"error":{"message":"{\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Unable to submit request because function call `default_api:get_temperature` in the 2. content block is missing a `thought_signature`. Learn more: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures\",\n    \"status\": \"INVALID_ARGUMENT\"\n  }\n}\n","type":"invalid_request_error","code":"400"}}

The error happens because the adapter incorrectly attaches the `thought_signature` saved in the message state to the text content block instead of the function call content block.

### After the fix

The following rule are applied to attach `thought_signature` to the content blocks following the [documentation](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/thought-signatures/#using-rest-or-manual-handling):

1. If there is no `thought_signature` and there are function blocks, then it will result in the 400 error from the upstream: content block is missing a `thought_signature`. To avoid the error, we use the fake thought signature, _(which is `skip_thought_signature_validator`)_ as recommended in the documentation.
2. If there is a `thought_signature` and there are any function call blocks, attach the thought signature to the **first** function block.
3. If there is a `thought_signature` and there are no function call blocks, attach the thought signature to the **last** block.