### PR TITLE
feat: support heartbeat for streaming chat completion responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
     - [Implicit caching](#implicit-caching)
   - [Authentication](#authentication)
     - [GCP Vertex AI](#gcp-vertex-ai)
-    - [Anthropic API / Google AI Platform](#anthropic-api--google-ai-platform)
+    - [Anthropic API / Mistral API / Google AI Platform](#anthropic-api--mistral-api--google-ai-platform)
     - [Anthropic Foundry](#anthropic-foundry)
   - [Development](#development)
     - [Development Environment](#development-environment)
@@ -678,6 +678,7 @@ Copy `.env.example` to `.env` and customize it for your environment:
 |CLAUDE_DEFAULT_MAX_TOKENS|1536|The default value of `max_tokens` chat completion parameter if it is not provided in the request.<br>**:warning: Using the variable is discouraged**.<br>Consider configuring the default in the DIAL Core Config instead as demonstrated in the [example below](#default-max_tokens-for-claude-models).|
 |GOOGLE_GENAI_MAX_RETRY_ATTEMPTS|0|How many times to retry Google GenAI chat model requests when the provider returns a retriable error|
 |ANTHROPIC_MAX_RETRY_ATTEMPTS|0|How many times to retry Anthropic chat model requests when the provider returns a retriable error|
+|SSE_HEARTBEAT_INTERVAL||If set, the adapter inserts ping comments into streaming chat completion responses after the connection has been idle for the specified number of seconds, helping prevent read timeouts when the upstream is unresponsive.|
 
 ### Default `max_tokens` for Claude models
 

--- a/aidial_adapter_vertexai/app.py
+++ b/aidial_adapter_vertexai/app.py
@@ -11,6 +11,7 @@ from aidial_adapter_vertexai.app_config import (
     init_vertex_ai,
 )
 from aidial_adapter_vertexai.chat_completion import VertexAIChatCompletion
+from aidial_adapter_vertexai.constants import SSE_HEARTBEAT_INTERVAL
 from aidial_adapter_vertexai.dial_api.exceptions import dial_exception_decorator
 from aidial_adapter_vertexai.dial_api.response import (
     ModelObject,
@@ -60,5 +61,9 @@ async def models():
     )
 
 
-app.add_chat_completion("{deployment_id}", VertexAIChatCompletion())
+app.add_chat_completion(
+    "{deployment_id}",
+    VertexAIChatCompletion(),
+    heartbeat_interval=SSE_HEARTBEAT_INTERVAL,
+)
 app.add_embeddings("{deployment_id}", VertexAIEmbeddings())

--- a/aidial_adapter_vertexai/constants.py
+++ b/aidial_adapter_vertexai/constants.py
@@ -1,0 +1,10 @@
+import os
+
+
+def _get_sse_heartbeat_interval() -> float | None:
+    if (val := os.getenv("SSE_HEARTBEAT_INTERVAL")) is None:
+        return None
+    return float(val)
+
+
+SSE_HEARTBEAT_INTERVAL = _get_sse_heartbeat_interval()


### PR DESCRIPTION
Analogous to https://github.com/epam/ai-dial-adapter-openai/pull/411

The feature is enabled by the new env var `SSE_HEARTBEAT_INTERVAL`: 

> If set, the adapter inserts ping comments into streaming chat completion responses after the connection has been idle for the specified number of seconds, helping prevent read timeouts when the upstream is unresponsive.

