### PR TITLE
fix: Veo: add generation stage to avoid timeout errors because of an idle response

### DIFF
--- a/aidial_adapter_vertexai/chat/veo/adapter.py
+++ b/aidial_adapter_vertexai/chat/veo/adapter.py
@@ -102,6 +102,7 @@ class VeoChatCompletionAdapter(ChatCompletionAdapter[VeoPrompt]):
             log.debug(f"request: {msg}")
 
         stage = consumer.choice.create_stage(name="Generation")
+        stage.open()
 
         with Timer("predict timing: {time}", log.debug):
             source = GenerateVideosSource(

--- a/aidial_adapter_vertexai/chat/veo/adapter.py
+++ b/aidial_adapter_vertexai/chat/veo/adapter.py
@@ -157,6 +157,10 @@ class VeoChatCompletionAdapter(ChatCompletionAdapter[VeoPrompt]):
 
         await consumer.add_attachment(attachment)
 
+        # Avoid generating empty content
+        completion = " "
+        await consumer.append_content(completion)
+
         completion_tokens = configuration.duration_seconds or 8
         await consumer.set_usage(
             TokenUsage(

--- a/aidial_adapter_vertexai/chat/veo/adapter.py
+++ b/aidial_adapter_vertexai/chat/veo/adapter.py
@@ -4,6 +4,7 @@ from logging import DEBUG
 from aidial_sdk.chat_completion import (
     Attachment,
     Message,
+    Status,
 )
 from aidial_sdk.exceptions import InternalServerError, InvalidRequestError
 from google.genai.client import Client as GenAIClient
@@ -100,6 +101,8 @@ class VeoChatCompletionAdapter(ChatCompletionAdapter[VeoPrompt]):
             )
             log.debug(f"request: {msg}")
 
+        stage = consumer.choice.create_stage(name="Generation")
+
         with Timer("predict timing: {time}", log.debug):
             source = GenerateVideosSource(
                 prompt=prompt.text or None,
@@ -111,6 +114,7 @@ class VeoChatCompletionAdapter(ChatCompletionAdapter[VeoPrompt]):
             )
             poll_interval = 3
             while not operation.done:
+                stage.append_content(".")
                 log.debug(f"Sleeping {poll_interval} seconds")
                 await asyncio.sleep(poll_interval)
                 operation = await self.client.aio.operations.get(operation)
@@ -120,11 +124,14 @@ class VeoChatCompletionAdapter(ChatCompletionAdapter[VeoPrompt]):
             log.debug(f"response: {json_dumps_short(response)}")
 
         if operation.error:
+            stage.close(status=Status.FAILED)
             msg = operation.error.get("message")
             if operation.error.get("code") == _GRPC_INVALID_ARGUMENT_CODE:
                 raise InvalidRequestError(msg or "Invalid argument")
             else:
                 raise InternalServerError(msg or "Internal server error")
+        else:
+            stage.close(status=Status.COMPLETED)
 
         if (generated_video := _extract_video(operation)) is None:
             raise RuntimeError("Expected video in response, but got none")
@@ -148,10 +155,6 @@ class VeoChatCompletionAdapter(ChatCompletionAdapter[VeoPrompt]):
             attachment.url = meta["url"]
 
         await consumer.add_attachment(attachment)
-
-        # Avoid generating empty content
-        completion = " "
-        await consumer.append_content(completion)
 
         completion_tokens = configuration.duration_seconds or 8
         await consumer.set_usage(

--- a/aidial_adapter_vertexai/chat/veo/adapter.py
+++ b/aidial_adapter_vertexai/chat/veo/adapter.py
@@ -101,9 +101,6 @@ class VeoChatCompletionAdapter(ChatCompletionAdapter[VeoPrompt]):
             )
             log.debug(f"request: {msg}")
 
-        stage = consumer.choice.create_stage(name="Generation")
-        stage.open()
-
         with Timer("predict timing: {time}", log.debug):
             source = GenerateVideosSource(
                 prompt=prompt.text or None,
@@ -113,6 +110,10 @@ class VeoChatCompletionAdapter(ChatCompletionAdapter[VeoPrompt]):
             operation = await self.client.aio.models.generate_videos(
                 model=self.model_id, source=source, config=config
             )
+
+            stage = consumer.choice.create_stage(name="Generation")
+            stage.open()
+
             poll_interval = 3
             while not operation.done:
                 stage.append_content(".")


### PR DESCRIPTION
When the generation of video takes a lot of time _(e.g. over a minute)_, it can trigger a timeout error in a load balancer between DIAL Chat and the adapter (such as [Nginx](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout)) because the streaming response doesn't produce anything during this period of time.

To avoid that we send something in a stage every time Veo is polled (which is every 3 seconds).