### PR TITLE
fix: block non-public addresses when downloading attachments

### DIFF
--- a/aidial_adapter_vertexai/chat/attachment_processor.py
+++ b/aidial_adapter_vertexai/chat/attachment_processor.py
@@ -97,9 +97,10 @@ class AttachmentProcessor(BaseModel):
             if isinstance(e, ResourceValidationError):
                 # Errors specific to a particular resource
                 return e.message
-            elif isinstance(e, UserError):
+            elif isinstance(e, UserError | ValidationError):
                 # Errors not specific to any particular resource
-                # typically raised by validators
+                # (e.g. UserError from validators, or a request-validation
+                # error such as an SSRF-rejected URL) must reach the client.
                 raise e
             else:
                 # Unexpected runtime exceptions

--- a/aidial_adapter_vertexai/dial_api/resource.py
+++ b/aidial_adapter_vertexai/dial_api/resource.py
@@ -5,10 +5,11 @@ from abc import ABC, abstractmethod
 from aidial_sdk.chat_completion import Attachment
 from pydantic import BaseModel, field_validator, model_validator
 
-from aidial_adapter_vertexai.dial_api.storage import FileStorage, download_file
+from aidial_adapter_vertexai.dial_api.storage import FileStorage
 from aidial_adapter_vertexai.utils.log_config import app_logger as log
 from aidial_adapter_vertexai.utils.resource import Resource
 from aidial_adapter_vertexai.utils.text import truncate_string
+from aidial_adapter_vertexai.utils.url import download_public_file
 
 # Python<=3.11 doesn't include .md in mimetypes by default
 # It was added in Python 3.12: https://github.com/python/cpython/pull/118594
@@ -202,4 +203,4 @@ async def _download_url(file_storage: FileStorage | None, url: str) -> bytes:
     if file_storage:
         return await file_storage.download_file(url)
     else:
-        return await download_file(url)
+        return await download_public_file(url)

--- a/aidial_adapter_vertexai/dial_api/ssrf.py
+++ b/aidial_adapter_vertexai/dial_api/ssrf.py
@@ -1,0 +1,66 @@
+import asyncio
+import ipaddress
+import socket
+from urllib.parse import urlsplit
+
+from aidial_adapter_vertexai.chat.errors import ValidationError
+
+# Only regular web schemes are allowed. Everything else (e.g. ``file``,
+# ``ftp``, ``gopher``) could be abused to reach local files or internal
+# services.
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+def _is_public_ip(ip: str) -> bool:
+    address = ipaddress.ip_address(ip)
+
+    # IPv4-mapped IPv6 addresses (e.g. ``::ffff:169.254.169.254``) must be
+    # judged by the semantics of the underlying IPv4 address. On Python < 3.13
+    # ``is_global`` does not unwrap them automatically.
+    if isinstance(address, ipaddress.IPv6Address):
+        mapped = address.ipv4_mapped
+        if mapped is not None:
+            address = mapped
+
+    return address.is_global
+
+
+async def _resolve_host(host: str) -> list[str]:
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as e:
+        raise ValidationError(
+            f"Can't resolve the host of the file URL: {host}"
+        ) from e
+    return [info[4][0] for info in infos]
+
+
+async def validate_public_url(url: str) -> None:
+    """Guard against SSRF by rejecting file URLs that don't point to a
+    publicly routable address.
+
+    An attacker can supply an arbitrary attachment URL (e.g. the cloud
+    metadata endpoint ``http://169.254.169.254``) and force the adapter to
+    fetch it. We only allow ``http``/``https`` URLs whose host resolves
+    exclusively to globally routable IP addresses.
+    """
+    parsed = urlsplit(url)
+
+    scheme = parsed.scheme.lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise ValidationError(
+            f"Downloading files over the {scheme or 'empty'!r} URL scheme "
+            "is not allowed"
+        )
+
+    host = parsed.hostname
+    if not host:
+        raise ValidationError("The file URL has no host")
+
+    for ip in await _resolve_host(host):
+        if not _is_public_ip(ip):
+            raise ValidationError(
+                "Downloading files from a non-public address "
+                f"({ip}) is not allowed"
+            )

--- a/aidial_adapter_vertexai/dial_api/storage.py
+++ b/aidial_adapter_vertexai/dial_api/storage.py
@@ -3,13 +3,35 @@ import io
 import mimetypes
 import os
 from collections.abc import Mapping
-from urllib.parse import unquote, urljoin
+from urllib.parse import unquote, urljoin, urlsplit
 
 import aiohttp
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
+from aidial_adapter_vertexai.chat.errors import ValidationError
+from aidial_adapter_vertexai.dial_api.ssrf import validate_public_url
 from aidial_adapter_vertexai.utils.log_config import app_logger as log
+
+# Redirects have to be followed manually so that every hop can be validated
+# against SSRF, otherwise a public URL could redirect to an internal address.
+_MAX_REDIRECTS = 5
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def _origin(url: str) -> tuple[str, str, int | None]:
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    return (
+        scheme,
+        (parsed.hostname or "").lower(),
+        (parsed.port or _DEFAULT_PORTS.get(scheme)),
+    )
+
+
+def _same_origin(a: str, b: str) -> bool:
+    return _origin(a) == _origin(b)
 
 
 class FileMetadata(TypedDict):
@@ -98,10 +120,14 @@ class FileStorage(BaseModel):
 
     async def download_file(self, link: str) -> bytes:
         url = self.attachment_link_to_url(link)
-        headers: Mapping[str, str] = {}
-        if url.lower().startswith(self.dial_url.lower()):
-            headers = self.auth_headers
-        return await download_file(url, headers)
+        # ``trusted_origin`` marks DIAL Core as the only host that may be
+        # reached without SSRF validation and that may receive the api-key.
+        # It is compared by origin (scheme/host/port), never by string
+        # prefix, otherwise URLs like ``http://<dial_url>@169.254.169.254``
+        # would bypass the check and leak the api-key.
+        return await download_file(
+            url, self.auth_headers, trusted_origin=self.dial_url
+        )
 
     async def get_human_readable_name(self, link: str) -> str:
         url = self.attachment_link_to_url(link)
@@ -120,13 +146,40 @@ class FileStorage(BaseModel):
         return link if link == decoded_link else repr(decoded_link)
 
 
-async def download_file(url: str, headers: Mapping[str, str] = {}) -> bytes:
-    async with (
-        aiohttp.ClientSession() as session,
-        session.get(url, headers=headers) as response,
-    ):
-        response.raise_for_status()
-        return await response.read()
+async def download_file(
+    url: str,
+    headers: Mapping[str, str] = {},
+    *,
+    trusted_origin: str | None = None,
+) -> bytes:
+    async with aiohttp.ClientSession() as session:
+        for _ in range(_MAX_REDIRECTS + 1):
+            # A hop is trusted only when it targets exactly the DIAL Core
+            # origin. Every other hop (including redirects that leave that
+            # origin) must be validated and must not receive the api-key.
+            trusted = trusted_origin is not None and _same_origin(
+                url, trusted_origin
+            )
+
+            if not trusted:
+                await validate_public_url(url)
+
+            async with session.get(
+                url,
+                headers=headers if trusted else {},
+                allow_redirects=False,
+            ) as response:
+                if response.status in _REDIRECT_STATUSES and (
+                    location := response.headers.get("Location")
+                ):
+                    # Re-validate the redirect target on the next iteration.
+                    url = urljoin(url, location)
+                    continue
+
+                response.raise_for_status()
+                return await response.read()
+
+    raise ValidationError("The file URL has too many redirects")
 
 
 def compute_hash_digest(data: bytes) -> str:

--- a/aidial_adapter_vertexai/dial_api/storage.py
+++ b/aidial_adapter_vertexai/dial_api/storage.py
@@ -3,35 +3,17 @@ import io
 import mimetypes
 import os
 from collections.abc import Mapping
-from urllib.parse import unquote, urljoin, urlsplit
+from urllib.parse import unquote, urljoin
 
 import aiohttp
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
-from aidial_adapter_vertexai.chat.errors import ValidationError
-from aidial_adapter_vertexai.dial_api.ssrf import validate_public_url
 from aidial_adapter_vertexai.utils.log_config import app_logger as log
-
-# Redirects have to be followed manually so that every hop can be validated
-# against SSRF, otherwise a public URL could redirect to an internal address.
-_MAX_REDIRECTS = 5
-_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
-_DEFAULT_PORTS = {"http": 80, "https": 443}
-
-
-def _origin(url: str) -> tuple[str, str, int | None]:
-    parsed = urlsplit(url)
-    scheme = parsed.scheme.lower()
-    return (
-        scheme,
-        (parsed.hostname or "").lower(),
-        (parsed.port or _DEFAULT_PORTS.get(scheme)),
-    )
-
-
-def _same_origin(a: str, b: str) -> bool:
-    return _origin(a) == _origin(b)
+from aidial_adapter_vertexai.utils.url import (
+    download_public_file,
+    has_same_origin,
+)
 
 
 class FileMetadata(TypedDict):
@@ -120,14 +102,21 @@ class FileStorage(BaseModel):
 
     async def download_file(self, link: str) -> bytes:
         url = self.attachment_link_to_url(link)
-        # ``trusted_origin`` marks DIAL Core as the only host that may be
-        # reached without SSRF validation and that may receive the api-key.
-        # It is compared by origin (scheme/host/port), never by string
-        # prefix, otherwise URLs like ``http://<dial_url>@169.254.169.254``
-        # would bypass the check and leak the api-key.
-        return await download_file(
-            url, self.auth_headers, trusted_origin=self.dial_url
-        )
+
+        # DIAL Core is the only origin allowed to receive the api-key, and it
+        # may legitimately live on a private address. Trust is decided by
+        # origin (scheme/host/port), never by string prefix, otherwise a URL
+        # like ``http://<dial_url>@169.254.169.254`` would bypass the SSRF
+        # check and leak the api-key.
+        if not has_same_origin(url, self.dial_url):
+            return await download_public_file(url)
+
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(url, headers=self.auth_headers) as response,
+        ):
+            response.raise_for_status()
+            return await response.read()
 
     async def get_human_readable_name(self, link: str) -> str:
         url = self.attachment_link_to_url(link)
@@ -144,42 +133,6 @@ class FileStorage(BaseModel):
         link = link.removeprefix(f"{bucket}/")
         decoded_link = unquote(link)
         return link if link == decoded_link else repr(decoded_link)
-
-
-async def download_file(
-    url: str,
-    headers: Mapping[str, str] = {},
-    *,
-    trusted_origin: str | None = None,
-) -> bytes:
-    async with aiohttp.ClientSession() as session:
-        for _ in range(_MAX_REDIRECTS + 1):
-            # A hop is trusted only when it targets exactly the DIAL Core
-            # origin. Every other hop (including redirects that leave that
-            # origin) must be validated and must not receive the api-key.
-            trusted = trusted_origin is not None and _same_origin(
-                url, trusted_origin
-            )
-
-            if not trusted:
-                await validate_public_url(url)
-
-            async with session.get(
-                url,
-                headers=headers if trusted else {},
-                allow_redirects=False,
-            ) as response:
-                if response.status in _REDIRECT_STATUSES and (
-                    location := response.headers.get("Location")
-                ):
-                    # Re-validate the redirect target on the next iteration.
-                    url = urljoin(url, location)
-                    continue
-
-                response.raise_for_status()
-                return await response.read()
-
-    raise ValidationError("The file URL has too many redirects")
 
 
 def compute_hash_digest(data: bytes) -> str:

--- a/aidial_adapter_vertexai/utils/url.py
+++ b/aidial_adapter_vertexai/utils/url.py
@@ -1,7 +1,9 @@
 import asyncio
 import ipaddress
 import socket
-from urllib.parse import urlsplit
+from urllib.parse import urljoin, urlsplit
+
+import aiohttp
 
 from aidial_adapter_vertexai.chat.errors import ValidationError
 
@@ -9,6 +11,33 @@ from aidial_adapter_vertexai.chat.errors import ValidationError
 # ``ftp``, ``gopher``) could be abused to reach local files or internal
 # services.
 _ALLOWED_SCHEMES = frozenset({"http", "https"})
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+# Redirects have to be followed manually so that every hop can be validated
+# against SSRF, otherwise a public URL could redirect to an internal address.
+_MAX_REDIRECTS = 5
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+
+
+def _origin(url: str) -> tuple[str, str, int | None]:
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    return (
+        scheme,
+        (parsed.hostname or "").lower(),
+        parsed.port or _DEFAULT_PORTS.get(scheme),
+    )
+
+
+def has_same_origin(a: str, b: str) -> bool:
+    """Whether two URLs share the same origin (scheme, host and port).
+
+    Origins are compared field by field. A string-prefix check must never be
+    used instead: e.g. ``http://<host>@169.254.169.254`` and
+    ``http://<host>.attacker.example`` both start with ``http://<host>`` yet
+    resolve to a completely different host.
+    """
+    return _origin(a) == _origin(b)
 
 
 def _is_public_ip(ip: str) -> bool:
@@ -64,3 +93,28 @@ async def validate_public_url(url: str) -> None:
                 "Downloading files from a non-public address "
                 f"({ip}) is not allowed"
             )
+
+
+async def download_public_file(url: str) -> bytes:
+    """Download a file from an untrusted, user-supplied URL.
+
+    Every hop (including redirect targets) is validated to point at a public
+    address before the request is made, so a public URL cannot bounce into an
+    internal one. No credentials are ever sent along this path.
+    """
+    async with aiohttp.ClientSession() as session:
+        for _ in range(_MAX_REDIRECTS + 1):
+            await validate_public_url(url)
+
+            async with session.get(url, allow_redirects=False) as response:
+                if response.status in _REDIRECT_STATUSES and (
+                    location := response.headers.get("Location")
+                ):
+                    # Re-validate the redirect target on the next iteration.
+                    url = urljoin(url, location)
+                    continue
+
+                response.raise_for_status()
+                return await response.read()
+
+    raise ValidationError("The file URL has too many redirects")

--- a/tests/unit_tests/test_ssrf.py
+++ b/tests/unit_tests/test_ssrf.py
@@ -1,0 +1,199 @@
+from collections.abc import Mapping
+
+import pytest
+
+from aidial_adapter_vertexai.chat.errors import ValidationError
+from aidial_adapter_vertexai.dial_api import storage as storage_module
+from aidial_adapter_vertexai.dial_api.ssrf import validate_public_url
+from aidial_adapter_vertexai.dial_api.storage import FileStorage, download_file
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # Cloud metadata endpoint (link-local).
+        "http://169.254.169.254/metadata/v1/instanceinfo",
+        "http://127.0.0.1/",
+        "http://localhost/secret",
+        "http://10.0.0.1/",
+        "http://192.168.1.1/",
+        "http://172.16.0.1/",
+        "http://0.0.0.0/",  # noqa: S104
+        "https://[::1]/",
+        "http://[::ffff:169.254.169.254]/",
+        # Decimal-encoded 127.0.0.1.
+        "http://2130706433/",
+    ],
+)
+async def test_rejects_non_public_address(url: str):
+    with pytest.raises(ValidationError, match="non-public address"):
+        await validate_public_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",
+        "ftp://8.8.8.8/",
+        "gopher://8.8.8.8/",
+        "//8.8.8.8/",  # empty scheme
+    ],
+)
+async def test_rejects_disallowed_scheme(url: str):
+    with pytest.raises(ValidationError, match="scheme is not allowed"):
+        await validate_public_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://8.8.8.8/file.txt",
+        "https://1.1.1.1/file.txt",
+        "https://[2606:4700:4700::1111]/file.txt",
+    ],
+)
+async def test_allows_public_address(url: str):
+    await validate_public_url(url)
+
+
+@pytest.mark.parametrize(
+    "link",
+    [
+        # ``userinfo`` trick: prefix matches dial_url but the real host is
+        # the cloud metadata endpoint.
+        "http://dial-core@169.254.169.254/metadata/v1/instanceinfo",
+        # A look-alike domain that merely starts with the dial_url string.
+        "http://dial-core.attacker.example/10.0.0.1",
+    ],
+)
+async def test_file_storage_does_not_trust_prefix_lookalikes(link: str):
+    storage = FileStorage(dial_url="http://dial-core", api_key="secret")
+    # A non-DIAL origin must be treated as untrusted and validated, so a
+    # non-public target is rejected before any authenticated request is made.
+    with pytest.raises(ValidationError):
+        await storage.download_file(link)
+
+
+class _FakeResponse:
+    def __init__(self, *, status: int, headers: dict, body: bytes):
+        self.status = status
+        self.headers = headers
+        self._body = body
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+    def raise_for_status(self) -> None:
+        if self.status >= 400:
+            raise AssertionError(f"unexpected status {self.status}")
+
+    async def read(self) -> bytes:
+        return self._body
+
+
+class _FakeSession:
+    """Minimal stand-in for ``aiohttp.ClientSession`` used to exercise the
+    manual redirect handling without touching the network."""
+
+    def __init__(self, routes: dict[str, _FakeResponse]):
+        self._routes = routes
+        self.calls: list[tuple[str, Mapping[str, str]]] = []
+
+    async def __aenter__(self) -> "_FakeSession":
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+    def get(self, url, *, headers, allow_redirects):
+        assert allow_redirects is False
+        self.calls.append((url, headers))
+        return self._routes[url]
+
+
+def _install_fake_session(
+    monkeypatch, routes: dict[str, _FakeResponse]
+) -> _FakeSession:
+    session = _FakeSession(routes)
+    monkeypatch.setattr(
+        storage_module.aiohttp, "ClientSession", lambda: session
+    )
+    return session
+
+
+def _redirect(location: str) -> _FakeResponse:
+    return _FakeResponse(status=302, headers={"Location": location}, body=b"")
+
+
+def _ok(body: bytes) -> _FakeResponse:
+    return _FakeResponse(status=200, headers={}, body=body)
+
+
+async def test_download_follows_public_redirect(monkeypatch):
+    _install_fake_session(
+        monkeypatch,
+        {
+            "http://8.8.8.8/a": _redirect("http://1.1.1.1/b"),
+            "http://1.1.1.1/b": _ok(b"redirected-bytes"),
+        },
+    )
+    assert await download_file("http://8.8.8.8/a") == b"redirected-bytes"
+
+
+async def test_download_blocks_redirect_into_internal(monkeypatch):
+    _install_fake_session(
+        monkeypatch,
+        {"http://8.8.8.8/a": _redirect("http://169.254.169.254/secret")},
+    )
+    # The redirect target is re-validated before the next request is made.
+    with pytest.raises(ValidationError, match="non-public address"):
+        await download_file("http://8.8.8.8/a")
+
+
+async def test_download_rejects_redirect_loop(monkeypatch):
+    _install_fake_session(
+        monkeypatch,
+        {"http://8.8.8.8/loop": _redirect("http://8.8.8.8/loop")},
+    )
+    with pytest.raises(ValidationError, match="too many redirects"):
+        await download_file("http://8.8.8.8/loop")
+
+
+async def test_trusted_origin_skips_validation_and_receives_auth(monkeypatch):
+    # The trusted storage origin may live on a private address and must stay
+    # reachable, and it is the only origin allowed to receive the api-key.
+    session = _install_fake_session(
+        monkeypatch,
+        {"http://10.0.0.5:1234/v1/files/x": _ok(b"trusted-bytes")},
+    )
+    storage = FileStorage(dial_url="http://10.0.0.5:1234", api_key="secret")
+
+    assert await storage.download_file("files/x") == b"trusted-bytes"
+
+    url, headers = session.calls[0]
+    assert url == "http://10.0.0.5:1234/v1/files/x"
+    assert headers == {"api-key": "secret"}
+
+
+async def test_redirect_off_trusted_origin_drops_auth(monkeypatch):
+    session = _install_fake_session(
+        monkeypatch,
+        {
+            "http://10.0.0.5:1234/v1/files/x": _redirect(
+                "http://8.8.8.8/public"
+            ),
+            "http://8.8.8.8/public": _ok(b"public-bytes"),
+        },
+    )
+    storage = FileStorage(dial_url="http://10.0.0.5:1234", api_key="secret")
+
+    assert await storage.download_file("files/x") == b"public-bytes"
+
+    # First (trusted) hop carries the api-key; the redirect leaving the
+    # trusted origin must not.
+    assert session.calls[0][1] == {"api-key": "secret"}
+    assert session.calls[1][0] == "http://8.8.8.8/public"
+    assert session.calls[1][1] == {}

--- a/tests/unit_tests/test_ssrf.py
+++ b/tests/unit_tests/test_ssrf.py
@@ -1,11 +1,14 @@
-from collections.abc import Mapping
-
 import pytest
 
 from aidial_adapter_vertexai.chat.errors import ValidationError
 from aidial_adapter_vertexai.dial_api import storage as storage_module
-from aidial_adapter_vertexai.dial_api.ssrf import validate_public_url
-from aidial_adapter_vertexai.dial_api.storage import FileStorage, download_file
+from aidial_adapter_vertexai.dial_api.storage import FileStorage
+from aidial_adapter_vertexai.utils import url as url_module
+from aidial_adapter_vertexai.utils.url import (
+    download_public_file,
+    has_same_origin,
+    validate_public_url,
+)
 
 
 @pytest.mark.parametrize(
@@ -57,6 +60,24 @@ async def test_allows_public_address(url: str):
 
 
 @pytest.mark.parametrize(
+    ("a", "b", "expected"),
+    [
+        ("http://dial-core/v1/files/x", "http://dial-core", True),
+        ("http://dial-core:80/v1/", "http://dial-core", True),
+        ("https://dial-core/v1/", "http://dial-core", False),
+        ("http://dial-core:8080/v1/", "http://dial-core", False),
+        # ``userinfo`` trick: the string starts with the dial_url, but the
+        # real host is the cloud metadata endpoint.
+        ("http://dial-core@169.254.169.254/x", "http://dial-core", False),
+        # Look-alike host that merely starts with the dial_url string.
+        ("http://dial-core.attacker.example/x", "http://dial-core", False),
+    ],
+)
+def test_has_same_origin(a: str, b: str, expected: bool):
+    assert has_same_origin(a, b) is expected
+
+
+@pytest.mark.parametrize(
     "link",
     [
         # ``userinfo`` trick: prefix matches dial_url but the real host is
@@ -96,11 +117,11 @@ class _FakeResponse:
 
 class _FakeSession:
     """Minimal stand-in for ``aiohttp.ClientSession`` used to exercise the
-    manual redirect handling without touching the network."""
+    download logic without touching the network."""
 
     def __init__(self, routes: dict[str, _FakeResponse]):
         self._routes = routes
-        self.calls: list[tuple[str, Mapping[str, str]]] = []
+        self.calls: list[tuple[str, object]] = []
 
     async def __aenter__(self) -> "_FakeSession":
         return self
@@ -108,19 +129,16 @@ class _FakeSession:
     async def __aexit__(self, *exc) -> bool:
         return False
 
-    def get(self, url, *, headers, allow_redirects):
-        assert allow_redirects is False
+    def get(self, url, *, headers=None, allow_redirects=True):
         self.calls.append((url, headers))
         return self._routes[url]
 
 
 def _install_fake_session(
-    monkeypatch, routes: dict[str, _FakeResponse]
+    monkeypatch, module, routes: dict[str, _FakeResponse]
 ) -> _FakeSession:
     session = _FakeSession(routes)
-    monkeypatch.setattr(
-        storage_module.aiohttp, "ClientSession", lambda: session
-    )
+    monkeypatch.setattr(module.aiohttp, "ClientSession", lambda: session)
     return session
 
 
@@ -132,41 +150,56 @@ def _ok(body: bytes) -> _FakeResponse:
     return _FakeResponse(status=200, headers={}, body=body)
 
 
-async def test_download_follows_public_redirect(monkeypatch):
+async def test_public_download_follows_public_redirect(monkeypatch):
     _install_fake_session(
         monkeypatch,
+        url_module,
         {
             "http://8.8.8.8/a": _redirect("http://1.1.1.1/b"),
             "http://1.1.1.1/b": _ok(b"redirected-bytes"),
         },
     )
-    assert await download_file("http://8.8.8.8/a") == b"redirected-bytes"
+    assert await download_public_file("http://8.8.8.8/a") == b"redirected-bytes"
 
 
-async def test_download_blocks_redirect_into_internal(monkeypatch):
+async def test_public_download_blocks_redirect_into_internal(monkeypatch):
     _install_fake_session(
         monkeypatch,
+        url_module,
         {"http://8.8.8.8/a": _redirect("http://169.254.169.254/secret")},
     )
     # The redirect target is re-validated before the next request is made.
     with pytest.raises(ValidationError, match="non-public address"):
-        await download_file("http://8.8.8.8/a")
+        await download_public_file("http://8.8.8.8/a")
 
 
-async def test_download_rejects_redirect_loop(monkeypatch):
+async def test_public_download_rejects_redirect_loop(monkeypatch):
     _install_fake_session(
         monkeypatch,
+        url_module,
         {"http://8.8.8.8/loop": _redirect("http://8.8.8.8/loop")},
     )
     with pytest.raises(ValidationError, match="too many redirects"):
-        await download_file("http://8.8.8.8/loop")
+        await download_public_file("http://8.8.8.8/loop")
 
 
-async def test_trusted_origin_skips_validation_and_receives_auth(monkeypatch):
+async def test_public_download_sends_no_credentials(monkeypatch):
+    session = _install_fake_session(
+        monkeypatch,
+        url_module,
+        {"http://8.8.8.8/file": _ok(b"public-bytes")},
+    )
+    assert await download_public_file("http://8.8.8.8/file") == b"public-bytes"
+    # The untrusted path must never attach any headers.
+    assert session.calls == [("http://8.8.8.8/file", None)]
+
+
+async def test_trusted_origin_receives_auth_and_skips_validation(monkeypatch):
     # The trusted storage origin may live on a private address and must stay
     # reachable, and it is the only origin allowed to receive the api-key.
     session = _install_fake_session(
         monkeypatch,
+        storage_module,
         {"http://10.0.0.5:1234/v1/files/x": _ok(b"trusted-bytes")},
     )
     storage = FileStorage(dial_url="http://10.0.0.5:1234", api_key="secret")
@@ -176,24 +209,3 @@ async def test_trusted_origin_skips_validation_and_receives_auth(monkeypatch):
     url, headers = session.calls[0]
     assert url == "http://10.0.0.5:1234/v1/files/x"
     assert headers == {"api-key": "secret"}
-
-
-async def test_redirect_off_trusted_origin_drops_auth(monkeypatch):
-    session = _install_fake_session(
-        monkeypatch,
-        {
-            "http://10.0.0.5:1234/v1/files/x": _redirect(
-                "http://8.8.8.8/public"
-            ),
-            "http://8.8.8.8/public": _ok(b"public-bytes"),
-        },
-    )
-    storage = FileStorage(dial_url="http://10.0.0.5:1234", api_key="secret")
-
-    assert await storage.download_file("files/x") == b"public-bytes"
-
-    # First (trusted) hop carries the api-key; the redirect leaving the
-    # trusted origin must not.
-    assert session.calls[0][1] == {"api-key": "secret"}
-    assert session.calls[1][0] == "http://8.8.8.8/public"
-    assert session.calls[1][1] == {}


### PR DESCRIPTION
## Summary

Attachment and image/file URLs supplied in chat requests were downloaded server-side without validation, allowing requests to be directed at non-public addresses.

This PR adds SSRF protection to the file download path via generic helpers in `aidial_adapter_vertexai/utils/url.py`:

- `validate_public_url(url)` — permits only `http`/`https` and rejects the URL unless its host resolves exclusively to globally routable IP addresses (`ipaddress.is_global`), covering loopback, private, link-local, unspecified, shared and other non-global ranges, including IPv4-mapped IPv6 forms. Hostnames are resolved asynchronously so the event loop is not blocked.
- `download_public_file(url)` — the untrusted download path: validates the URL, follows redirects manually with a small cap and re-validates every hop (so a public URL cannot bounce into an internal one), and never sends credentials.
- `has_same_origin(a, b)` — compares origin (scheme/host/port), never a string prefix.

Trust model in `FileStorage.download_file`: if the URL shares the DIAL storage origin it is fetched directly with the api-key (the storage may legitimately live on a private address); otherwise it goes through `download_public_file` with no credentials. Origin comparison is used deliberately instead of `startswith` — a prefix check is bypassable, e.g. `http://<dial_url>@169.254.169.254/...` or `http://<dial_url>.attacker.example/...` both "start with" the base URL yet resolve to a different/internal host, which would skip validation and leak the api-key. All user-URL fetches (attachments + image/file content parts) route through this path; `data:`/base64/local decoding is unaffected.

Rejected requests surface as a request-validation error (`invalid_argument`, 4xx) aimed at the API client.

## Test plan

- New unit tests (`tests/unit_tests/test_ssrf.py`, hermetic — no real network) cover:
  - Blocked addresses (private/loopback/link-local/IPv4-mapped/decimal-encoded).
  - Blocked URL schemes (`file`/`ftp`/`gopher`/empty).
  - Allowed public hosts (IPv4 and IPv6 literals).
  - `has_same_origin` positive/negative cases (scheme, port, userinfo `@` trick, look-alike host).
  - `download_public_file`: public-redirect follow, redirect-into-internal rejection, redirect-loop rejection, and no-credentials assertion.
  - Trusted-origin fetch receives the api-key and skips validation; prefix look-alike links are treated as untrusted, validated, rejected, and never sent auth.