### PR TITLE
feat: Gemini: support safety_settings configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,31 @@ The Gemini 3 series model also supports [thinking_level](https://ai.google.dev/g
 > [!NOTE]
 > You cannot use both `reasoning_effort` and the `thinking_budget` parameters in the same request.
 
+##### Gemini safety settings
+
+The Gemini models accept [safety settings](https://ai.google.dev/gemini-api/docs/safety-settings) that control content filtering per harm category:
+
+```json
+{
+  "custom_fields": {
+    "configuration": {
+      "safety_settings": [
+        {
+          "category": "HARM_CATEGORY_HARASSMENT",
+          "threshold": "BLOCK_ONLY_HIGH"
+        },
+        {
+          "category": "HARM_CATEGORY_HATE_SPEECH",
+          "threshold": "BLOCK_NONE"
+        }
+      ]
+    }
+  }
+}
+```
+
+Consult the [documentation](https://ai.google.dev/gemini-api/docs/safety-settings) for the supported harm categories and block thresholds.
+
 ##### Gemini 2.5 Flash Image model
 
 The Gemini 2.5 Flash Image support configuration of parameters controlling generation of images:

--- a/aidial_adapter_vertexai/chat/gemini/adapter.py
+++ b/aidial_adapter_vertexai/chat/gemini/adapter.py
@@ -13,7 +13,11 @@ from google.genai.types import (
 from google.genai.types import (
     GenerateContentResponse as GenAIGenerateContentResponse,
 )
-from google.genai.types import ImageConfigDict, ThinkingConfigDict
+from google.genai.types import (
+    ImageConfigDict,
+    SafetySettingDict,
+    ThinkingConfigDict,
+)
 from pydantic import Field
 from typing_extensions import override
 
@@ -114,6 +118,13 @@ class ThinkingConfig(ExtraAllowModel):
 class GeminiConfigurationModel(ExtraForbidModel):
     thinking: ThinkingConfig | None = None
     image_config: ImageConfig | None = None
+    safety_settings: list[SafetySettingDict] | None = Field(
+        default=None,
+        description=(
+            "The safety settings controlling content filtering. "
+            "See https://ai.google.dev/gemini-api/docs/safety-settings"
+        ),
+    )
 
 
 @dataclass
@@ -229,6 +240,10 @@ class GeminiGenAIChatCompletionAdapter(
                 thinking_config | configuration.thinking.to_thinking_config()
             )
 
+        safety_settings: list[SafetySettingDict] | None = None
+        if configuration and configuration.safety_settings:
+            safety_settings = configuration.safety_settings
+
         return create_genai_generation_config(
             params,
             supports_image_generation=self.supports_image_generation,
@@ -237,6 +252,7 @@ class GeminiGenAIChatCompletionAdapter(
             system_instruction=prompt.system,
             thinking_config=thinking_config,
             image_config=image_config,
+            safety_settings=safety_settings,
         )
 
     def _get_token_count_config(

--- a/aidial_adapter_vertexai/chat/gemini/generation_config.py
+++ b/aidial_adapter_vertexai/chat/gemini/generation_config.py
@@ -4,7 +4,11 @@ from google.genai.types import CountTokensConfigDict as GenAICountTokensConfig
 from google.genai.types import (
     GenerateContentConfigDict as GenAIGenerationConfig,
 )
-from google.genai.types import ImageConfigDict, ThinkingConfigDict
+from google.genai.types import (
+    ImageConfigDict,
+    SafetySettingDict,
+    ThinkingConfigDict,
+)
 from google.genai.types import Part as GenAIPart
 from google.genai.types import ToolDict as GenAITool
 
@@ -29,6 +33,7 @@ def create_genai_generation_config(
     system_instruction: list[GenAIPart] | None,
     thinking_config: ThinkingConfigDict | None,
     image_config: ImageConfigDict | None,
+    safety_settings: list[SafetySettingDict] | None,
 ) -> GenAIGenerationConfig:
     validate_n_parameter(params)
 
@@ -59,6 +64,7 @@ def create_genai_generation_config(
         response_modalities=response_modalities,
         thinking_config=thinking_config,
         image_config=image_config,
+        safety_settings=safety_settings,
     )
 
 

--- a/tests/unit_tests/test_configuration.py
+++ b/tests/unit_tests/test_configuration.py
@@ -3,7 +3,9 @@ from dataclasses import dataclass
 import httpx
 import openai
 import pytest
+from pydantic import ValidationError
 
+from aidial_adapter_vertexai.chat.gemini.adapter import GeminiConfigurationModel
 from aidial_adapter_vertexai.deployments import ChatCompletionDeployment as D
 from tests.conftest import get_extra_headers
 from tests.utils.exception import ExpectedException, expected_exception
@@ -83,6 +85,18 @@ async def test_gemini_supports_image_config(
     )
 
 
+@pytest.mark.parametrize(
+    "deployment",
+    _gemini_deployments_with_thinking + _gemini_deployments_with_imagen,
+)
+async def test_gemini_supports_safety_settings(
+    test_http_client: httpx.AsyncClient, deployment: D
+):
+    assert await _configuration_has_field(
+        test_http_client, deployment, "safety_settings"
+    )
+
+
 @pytest.mark.parametrize("deployment", _claude_deployments)
 async def test_claude_supports_citations(
     test_http_client: httpx.AsyncClient, deployment: D
@@ -90,6 +104,45 @@ async def test_claude_supports_citations(
     assert await _configuration_has_field(
         test_http_client, deployment, "enable_citations"
     )
+
+
+def test_gemini_safety_settings_must_be_a_list():
+    with pytest.raises(ValidationError) as exc_info:
+        GeminiConfigurationModel.model_validate(
+            {
+                "safety_settings": {
+                    "category": "HARM_CATEGORY_HATE_SPEECH",
+                    "threshold": "BLOCK_ONLY_HIGH",
+                }
+            }
+        )
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert errors[0]["loc"] == ("safety_settings",)
+    assert errors[0]["type"] == "list_type"
+    assert errors[0]["msg"] == "Input should be a valid list"
+
+
+def test_gemini_safety_settings_reject_extra_fields():
+    with pytest.raises(ValidationError) as exc_info:
+        GeminiConfigurationModel.model_validate(
+            {
+                "safety_settings": [
+                    {
+                        "category": "HARM_CATEGORY_HATE_SPEECH",
+                        "threshold": "BLOCK_ONLY_HIGH",
+                        "extra_field": "value",
+                    }
+                ]
+            }
+        )
+
+    errors = exc_info.value.errors()
+    assert len(errors) == 1
+    assert errors[0]["loc"] == ("safety_settings", 0, "extra_field")
+    assert errors[0]["type"] == "extra_forbidden"
+    assert errors[0]["msg"] == "Extra inputs are not permitted"
 
 
 @dataclass


### PR DESCRIPTION
Fixes #504

### Description of changes
- Add `safety_settings` field to `GeminiConfigurationModel`, reusing the Gemini SDK `SafetySettingDict` type so Pydantic handles parsing.
- Forward `safety_settings` through to the Gemini `GenerateContentConfig` request.
- Document the new configuration in the README.
- Add unit tests covering schema exposure and validation (list-type and extra-field rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)