### PR TITLE
ci: re-use venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ POETRY_PYTHON ?= python
 PYDANTIC_V2 ?= 1
 VENV_DIR ?= .venv
 
-# Check for CI environment
 # Any non-empty CI value (even 'false' or '0') means that CI is enabled
 CI ?=
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ POETRY_PYTHON ?= python
 PYDANTIC_V2 ?= 1
 VENV_DIR ?= .venv
 
+# Check for CI environment
+# Empty string means false in Makefile
+CI ?=
+
 .PHONY: all init_env install build serve clean lint format test integration_tests docker_build docker_run
 
 -include .env.dev
@@ -15,7 +19,7 @@ export
 all: build
 
 init_env:
-	$(POETRY) env use $(POETRY_PYTHON)
+	$(if $(CI),,$(POETRY) env use $(POETRY_PYTHON))
 
 install: init_env
 	$(POETRY) install

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PYDANTIC_V2 ?= 1
 VENV_DIR ?= .venv
 
 # Check for CI environment
-# Empty string means false in Makefile
+# Any non-empty CI value (even 'false' or '0') means that CI is enabled
 CI ?=
 
 .PHONY: all init_env install build serve clean lint format test integration_tests docker_build docker_run

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ VENV_DIR ?= .venv
 # Check for CI environment
 # Empty string means false in Makefile
 CI ?=
-NOX_DEFAULT_VENV_BACKEND := $(if $(CI),none,virtualenv)
 
 .PHONY: all init_env install build serve clean lint format test integration_tests docker_build docker_run
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ VENV_DIR ?= .venv
 # Check for CI environment
 # Empty string means false in Makefile
 CI ?=
+NOX_DEFAULT_VENV_BACKEND := $(if $(CI),none,virtualenv)
 
 .PHONY: all init_env install build serve clean lint format test integration_tests docker_build docker_run
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,6 @@
 import nox
 
 nox.options.reuse_existing_virtualenvs = True
-nox.options.default_venv_backend = "none"
 
 SRC = ["aidial_adapter_vertexai", "tests", "noxfile.py"]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,11 @@
+import os
 import nox
 
 nox.options.reuse_existing_virtualenvs = True
+# Use passthrough (no venv) backend in CI, isolated venv locally
+nox.options.default_venv_backend = (
+    "none" if os.environ.get("CI") else "virtualenv"
+)
 
 SRC = ["aidial_adapter_vertexai", "tests", "noxfile.py"]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,7 +27,7 @@ def lint(session: nox.Session):
 @nox.session
 def format(session: nox.Session):
     """Runs linters and fixers"""
-    session.run("poetry", "install", "--with", "lint", external=True)
+    session.run("poetry", "install", "--only", "lint", external=True)
     session.run("ruff", "check", "--fix", *SRC)
     session.run("ruff", "format", *SRC)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,10 +3,8 @@ import os
 import nox
 
 nox.options.reuse_existing_virtualenvs = True
-# Use passthrough (no venv) backend in CI, isolated venv locally
-nox.options.default_venv_backend = (
-    "none" if os.environ.get("CI") else "virtualenv"
-)
+if os.environ.get("CI"):
+    nox.options.default_venv_backend = "none"
 
 SRC = ["aidial_adapter_vertexai", "tests", "noxfile.py"]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,5 @@
 import os
+
 import nox
 
 nox.options.reuse_existing_virtualenvs = True

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,7 @@
 import nox
 
 nox.options.reuse_existing_virtualenvs = True
+nox.options.default_venv_backend = "none"
 
 SRC = ["aidial_adapter_vertexai", "tests", "noxfile.py"]
 
@@ -23,7 +24,7 @@ def lint(session: nox.Session):
 @nox.session
 def format(session: nox.Session):
     """Runs linters and fixers"""
-    session.run("poetry", "install", "--only", "lint", external=True)
+    session.run("poetry", "install", "--with", "lint", external=True)
     session.run("ruff", "check", "--fix", *SRC)
     session.run("ruff", "format", *SRC)
 


### PR DESCRIPTION
CI speed-up:
- skip `poetry env use` when running in CI environment - no need to recreate the venv we already prepared in workflow script (`python_prepare` action)
- instruct **nox** to reuse the existing venv (created by **poetry**) instead of building a fresh one per session.

For local execution everything stays the same