### PR TITLE
fix: support AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE for EKS Pod Identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,8 @@ When the adapter container is deployed on AWS ECS Fargate, ECS EC2 with task rol
 |---|---|
 |`AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`|Set by the ECS runtime for task roles. Combined with `http://169.254.170.2` to fetch credentials.|
 |`AWS_CONTAINER_CREDENTIALS_FULL_URI`|Set by EKS Pod Identity (and similar non-loopback runtimes). Used as-is to fetch credentials.|
+|`AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`|Set by EKS Pod Identity. Points to the token file whose content is sent in the `Authorization` header. Re-read on every credentials refresh, since the token is rotated.|
+|`AWS_CONTAINER_AUTHORIZATION_TOKEN`|Alternative to the `_FILE` variant: the token value itself. Ignored when `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` is set.|
 |`GOOGLE_APPLICATION_CREDENTIALS`|Points to a Workload Identity Federation credential configuration file with `type=external_account`.|
 
 At least one of `AWS_CONTAINER_CREDENTIALS_*_URI` must be set, as well as `GOOGLE_APPLICATION_CREDENTIALS`. Otherwise, the adapter fails with the 401 authentication error:

--- a/aidial_adapter_vertexai/aws_credentials.py
+++ b/aidial_adapter_vertexai/aws_credentials.py
@@ -1,5 +1,6 @@
 import json
 import os
+import pathlib
 import urllib.request
 from urllib.parse import urljoin
 
@@ -11,7 +12,16 @@ from aidial_adapter_vertexai.utils.log_config import app_logger as _log
 _RELATIVE = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
 _FULL = "AWS_CONTAINER_CREDENTIALS_FULL_URI"
 _AUTH = "AWS_CONTAINER_AUTHORIZATION_TOKEN"
+_AUTH_FILE = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"
 _ECS_AGENT = "http://169.254.170.2"
+
+
+def _read_auth_token() -> str | None:
+    # EKS Pod Identity passes the token via a file which is rotated,
+    # so it must be re-read on every credentials refresh.
+    if token_file := os.environ.get(_AUTH_FILE):
+        return pathlib.Path(token_file).read_text().strip()
+    return os.environ.get(_AUTH)
 
 
 class _CredentialsSupplier(aws.AwsSecurityCredentialsSupplier):
@@ -22,7 +32,7 @@ class _CredentialsSupplier(aws.AwsSecurityCredentialsSupplier):
         self, context, request
     ) -> aws.AwsSecurityCredentials:
         headers = {}
-        if (token := os.environ.get(_AUTH)) is not None:
+        if (token := _read_auth_token()) is not None:
             headers["Authorization"] = token
         # URL was resolved at startup from AWS_CONTAINER_CREDENTIALS_{FULL,RELATIVE}_URI
         # (link-local for ECS, FQDN for EKS Pod Identity). Not user input.

--- a/tests/unit_tests/test_aws_credentials.py
+++ b/tests/unit_tests/test_aws_credentials.py
@@ -98,3 +98,23 @@ def test_supplier_reads_from_full_uri_with_auth_token(monkeypatch):
 
     assert captured["url"] == "http://eks.example/creds"
     assert captured["headers"].get("Authorization") == "Bearer xyz"
+
+
+def test_supplier_reads_auth_token_from_file(monkeypatch, tmp_path):
+    token_path = tmp_path / "eks-pod-identity-token"
+    token_path.write_text("eks-token\n")
+    monkeypatch.delenv("AWS_CONTAINER_AUTHORIZATION_TOKEN", raising=False)
+    monkeypatch.setenv(
+        "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", str(token_path)
+    )
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["headers"] = dict(req.header_items())
+        return io.BytesIO(json.dumps(_AWS_CREDS_JSON).encode())
+
+    with patch("urllib.request.urlopen", fake_urlopen):
+        supplier = _CredentialsSupplier("http://169.254.170.23/v1/credentials")
+        supplier.get_aws_security_credentials(None, None)
+
+    assert captured["headers"].get("Authorization") == "eks-token"


### PR DESCRIPTION
When running under EKS Pod Identity, the agent at `AWS_CONTAINER_CREDENTIALS_FULL_URI` rejects credential requests that carry no `Authorization` header with `HTTP 400: Bad Request`, which surfaced as a 500 on every chat completion. EKS supplies that token through `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`, which the credentials supplier did not read.

Ref: [Container credential provider settings](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html).

## Server API changes

Two environment variables are now recognized:

|Name|Comment|
|---|---|
|`AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`|Set by EKS Pod Identity. Points to the token file whose content is sent in the `Authorization` header. Re-read on every credentials refresh, since the token is rotated.|
|`AWS_CONTAINER_AUTHORIZATION_TOKEN`|Alternative to the `_FILE` variant: the token value itself. Ignored when `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` is set.|

Both are optional; neither is required outside EKS Pod Identity. No HTTP API of the adapter changed.