### PR TITLE
ci(deps): bump epam/ai-dial-ci from 4.9.0 to 4.11.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,8 @@ updates:
       day: "wednesday"
       time: "09:00"
     commit-message:
-      # Prefix all commit messages with "chore: "
-      prefix: "chore"
+      prefix: "ci"
+      include: scope
     groups:
       ai-dial-ci:
         applies-to: version-updates

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,4 @@
 
 <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
 
-- [ ] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
-
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/workflows/cleanup-untagged-images.yml
+++ b/.github/workflows/cleanup-untagged-images.yml
@@ -14,3 +14,6 @@ jobs:
       - uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
         with:
           delete-untagged: true
+          delete-ghost-images: true # Delete indexes with no manifests
+          delete-partial-images: true # Delete indexes which refer to at least one non-existent manifest
+          delete-orphaned-images: true # Delete dangling referrers, e.g. SBOMs, signatures, etc. that refer to non-existent digest

--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -15,6 +15,7 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       - name: Approve PR
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -14,7 +14,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.registry_package.package_version.container_metadata.tag.name == 'development' ||
       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'development')
-    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.9.0
+    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.11.0
     with:
       gitlab-project-id: "3000"
     secrets:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   pr-title-check:
-    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.9.0
+    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.11.0
     secrets:
       ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/python_docker_pr.yml@4.9.0
+    uses: epam/ai-dial-ci/.github/workflows/python_docker_pr.yml@4.11.0
     secrets: inherit
     with:
       python-version: 3.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/python_docker_release.yml@4.9.0
+    uses: epam/ai-dial-ci/.github/workflows/python_docker_release.yml@4.11.0
     with:
       promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
       python-version: 3.11

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -5,7 +5,9 @@ on:
 jobs:
   slashCommandDispatch:
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request }}
+    if: |
+      github.event.issue.pull_request &&
+      github.event.issue.state == 'open'
     steps:
       - name: Slash Command Dispatch
         id: scd

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,78 +1,14 @@
 ---
+analyzer:
+  skip_excluded: true
 excludes:
   scopes:
-  - pattern: "dev"
-    reason: "DEV_DEPENDENCY_OF"
-    comment: "Packages for development only."
-  - pattern: "lint"
-    reason: "DEV_DEPENDENCY_OF"
-    comment: "Packages for static code analysis only."
-  - pattern: "test"
-    reason: "TEST_DEPENDENCY_OF"
-    comment: "Packages for testing only."
-license_choices:
-  repository_license_choices:
-  - given: FTL OR GPL-2.0-or-later
-    choice: FTL
-resolutions:
-  rule_violations:
-    - message: ".*PyPI::setuptools:78\\.1\\.1.*"
-      reason: "CANT_FIX_EXCEPTION"
-      comment: "BSD 3-Clause New or Revised License: https://github.com/pypa/setuptools/blob/v78.1.1/LICENSE"
-    - message: ".*PyPI::aiocache:0\\.12\\.2.*"
-      reason: 'CANT_FIX_EXCEPTION'
-      comment: 'BSD 3-Clause "New" or "Revised" License: https://github.com/aio-libs/aiocache/blob/v0.12.2/LICENSE'
-    - message: ".*PyPI::httpcore:1\\.0\\.9.*"
-      reason: 'CANT_FIX_EXCEPTION'
-      comment: 'BSD 3-Clause "New" or "Revised" License: https://github.com/encode/httpcore/blob/1.0.9/LICENSE.md'
-    - message: ".*PyPI::httpx:0\\.28\\.1.*"
-      reason: 'CANT_FIX_EXCEPTION'
-      comment: 'BSD 3-Clause "New" or "Revised" License: https://github.com/encode/httpx/blob/0.28.1/LICENSE.md'
-    - message: ".*PyPI::numpy:2\\.0\\.0.*"
-      reason: 'CANT_FIX_EXCEPTION'
-      comment: 'BSD License: https://github.com/numpy/numpy/blob/v2.0.0/LICENSE.txt'
-    - message: ".*PyPI::setuptools:78\\.1\\.1.*"
-      reason: 'CANT_FIX_EXCEPTION'
-      comment: 'MIT License: https://github.com/pypa/setuptools/blob/v78.1.1/LICENSE'
-    - message: ".*PyPI::pillow:.*"
-      reason: "CANT_FIX_EXCEPTION"
-      comment: "ORT cannot pick up license information"
-    - message: ".*PyPI::opentelemetry.*"
-      reason: "CANT_FIX_EXCEPTION"
-      comment: "ORT cannot pick up license information"
-    - message: ".*PyPI::google-genai:.*"
-      reason: "CANT_FIX_EXCEPTION"
-      comment: "ORT cannot pick up license information"
-    - message: ".*PyPI::azure-identity:.*"
-      reason: "CANT_FIX_EXCEPTION"
-      comment: "ORT cannot pick up license information"
-    - message: ".*PyPI::pypdf:.*"
-      reason: 'CANT_FIX_EXCEPTION'
-      comment: "ORT cannot pick up license information"
-    - message: ".*PyPI::starlette:.*"
-      reason: 'CANT_FIX_EXCEPTION'
-      comment: "ORT cannot pick up license information"
-    - message: ".*PyPI::urllib3:.*"
-      reason: "CANT_FIX_EXCEPTION"
-      comment: "ORT cannot pick up license information"
-    - message: ".*PyPI::fastapi:.*"
-      reason: "CANT_FIX_EXCEPTION"
-      comment: "ORT cannot pick up license information"
-    - message: ".*PyPI::cryptography:.*"
-      reason: "CANT_FIX_EXCEPTION"
-      comment: "ORT cannot pick up license information"
-    - message: ".*PyPI::cffi:.*"
-      reason: "CANT_FIX_EXCEPTION"
-      comment: "ORT cannot pick up license information"
-    - message: ".*PyPI::pyjwt:.*"
-      reason: "CANT_FIX_EXCEPTION"
-      comment: "ORT cannot pick up license information"
-    - message: ".*PyPI::aidial-sdk:.*"
-      reason: "CANT_FIX_EXCEPTION"
-      comment: "ORT cannot pick up license information"
-    - message: ".*PyPI::aidial-adapter-anthropic:.*"
-      reason: "CANT_FIX_EXCEPTION"
-      comment: "ORT cannot pick up license information"
-    - message: ".*PyPI::(anthropic|typing-extensions|mistralai|google-auth|typing-inspection|idna):.*"
-      reason: "CANT_FIX_EXCEPTION"
-      comment: "ORT cannot pick up license information"
+    - pattern: "dev"
+      reason: "DEV_DEPENDENCY_OF"
+      comment: "Packages for development only."
+    - pattern: "lint"
+      reason: "DEV_DEPENDENCY_OF"
+      comment: "Packages for static code analysis only."
+    - pattern: "test"
+      reason: "TEST_DEPENDENCY_OF"
+      comment: "Packages for testing only."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ requires-python = ">=3.11,<4"
 dynamic = ["dependencies"]
 
 [project.urls]
-Homepage = "https://epam-rail.com"
-Documentation = "https://epam-rail.com/dial_api"
+Homepage = "https://dialx.ai"
+Documentation = "https://dialx.ai/dial_api"
 Repository = "https://github.com/epam/ai-dial-adapter-vertexai/"
 
 [tool.poetry]


### PR DESCRIPTION
### Description of changes

- bump epam/ai-dial-ci from `4.9.0` to `4.11.0`
- align workflows with recommended configuration; this delivers minor fixes
- drop ORT resolutions in favor of shared curations in [ai-dial-ort-config](https://github.com/epam/ai-dial-ort-config/)
- update homepage URL in project metadata 